### PR TITLE
Prepare 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] — 2022-03-23
+
+Add `impl_scope!` function-like macro (derived from `kas_macros::widget!`) and
+`#[impl_default]` attribute macro.
+
 ## [0.1.0] — 2022-03-21
 
-New release, including the `autoimpl` macro (extracted from `kas-macros` crate).
+New release, including the `#[autoimpl]` attribute macro (extracted from
+`kas-macros` crate).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "impl-tools"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2021"
 license = "MIT/Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The [COPYRIGHT](COPYRIGHT) file includes a list of contributors who claim
 copyright on this project. This list may be incomplete; new contributors may
 optionally add themselves to this list.
 
-The KAS library is published under the terms of the Apache License, Version 2.0.
+The impl-tools library is published under the terms of the Apache License, Version 2.0.
 You may obtain a copy of this licence from the [LICENSE](LICENSE) file or on
 the following webpage: <https://www.apache.org/licenses/LICENSE-2.0>
 

--- a/src/autoimpl.rs
+++ b/src/autoimpl.rs
@@ -12,7 +12,6 @@ use proc_macro_error::{emit_call_site_error, emit_error};
 use quote::{quote, quote_spanned, ToTokens, TokenStreamExt};
 use syn::parse::{Error, Parse, ParseStream, Result};
 use syn::punctuated::Punctuated;
-use syn::spanned::Spanned;
 use syn::token::Comma;
 use syn::{
     Field, Fields, FnArg, Ident, ItemStruct, ItemTrait, Member, Path, PathArguments, Token,
@@ -244,7 +243,7 @@ impl Parse for AutoImpl {
             let ignore: kw::ignore = input.parse()?;
             if matches!(mode, Mode::Default) {
                 emit_error!(
-                    ignore.span(),
+                    ignore,
                     "cannot ignore fields when implementing std::default::Default"
                 );
             }
@@ -342,10 +341,10 @@ pub fn autoimpl_trait(mut attr: AutoImpl, item: ItemTrait) -> TokenStream {
                             });
                         }
                         TraitItem::Macro(item) => {
-                            emit_error!(item.span(), "unsupported: macro item in trait");
+                            emit_error!(item, "unsupported: macro item in trait");
                         }
                         TraitItem::Verbatim(item) => {
-                            emit_error!(item.span(), "unsupported: verbatim item in trait");
+                            emit_error!(item, "unsupported: verbatim item in trait");
                         }
 
                         #[cfg(test)]
@@ -386,7 +385,7 @@ pub fn autoimpl_struct(attr: AutoImpl, item: ItemStruct) -> TokenStream {
             }
             _ => (),
         }
-        emit_error!(mem.span(), "not a struct field");
+        emit_error!(mem, "not a struct field");
     }
     match &attr.body {
         Body::For { .. } => {

--- a/src/default.rs
+++ b/src/default.rs
@@ -11,8 +11,9 @@ use syn::parse::{Error, Parse, ParseStream, Result};
 use syn::punctuated::Punctuated;
 use syn::{token, Attribute, Expr, Generics, Ident, Token, Type, Visibility};
 
-pub fn impl_default(attr: TokenStream, scope: &mut Scope) -> Result<()> {
+pub fn impl_default(attr: TokenStream, attr_span: Span, scope: &mut Scope) -> Result<()> {
     let attr: Attr = syn::parse2(attr)?;
+
     if let Some(expr) = attr.as_expr() {
         scope
             .generated
@@ -36,7 +37,7 @@ pub fn impl_default(attr: TokenStream, scope: &mut Scope) -> Result<()> {
             },
             _ => {
                 return Err(Error::new(
-                    scope.item.token_span(),
+                    attr_span,
                     "must specify value as `#[impl_default(value)]` on non-struct type",
                 ));
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,7 +237,8 @@ pub fn impl_default(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// -   `Clone` — implements `std::clone::Clone`; ignored fields are
 ///     initialised with `Default::default()`
 /// -   `Debug` — implements `std::fmt::Debug`; ignored fields are not printed
-/// -   `Default` — implements `std::default::Default`
+/// -   `Default` — implements `std::default::Default` using
+///     `Default::default()` for all fields (see also [`impl_default`])
 ///
 /// ### Parameter syntax
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,7 @@ extern crate proc_macro;
 use proc_macro::TokenStream;
 use proc_macro_error::{emit_call_site_error, emit_error, proc_macro_error};
 use syn::parse_macro_input;
-use syn::{spanned::Spanned, Item};
+use syn::Item;
 
 mod autoimpl;
 mod default;
@@ -193,7 +193,7 @@ pub fn impl_default(attr: TokenStream, item: TokenStream) -> TokenStream {
             }
             item => {
                 emit_error!(
-                    item.span(),
+                    item,
                     "default: only supports enum, struct, type alias and union items"
                 );
             }
@@ -339,10 +339,7 @@ pub fn autoimpl(attr: TokenStream, item: TokenStream) -> TokenStream {
                 Item::Struct(item) => autoimpl::autoimpl_struct(attr, item),
                 Item::Trait(item) => autoimpl::autoimpl_trait(attr, item),
                 item => {
-                    emit_error!(
-                        item.span(),
-                        "autoimpl: only supports struct and trait items"
-                    );
+                    emit_error!(item, "autoimpl: only supports struct and trait items");
                     return toks;
                 }
             }));

--- a/tests/impl_default.rs
+++ b/tests/impl_default.rs
@@ -15,7 +15,7 @@ fn lr() {
 }
 
 impl_scope! {
-    #[impl_default UnsafeNumber { as_u64: 0 }]
+    #[impl_default(UnsafeNumber { as_u64: 0 })]
     union UnsafeNumber {
         as_u64: u64,
         as_f64: f64,

--- a/tests/impl_default.rs
+++ b/tests/impl_default.rs
@@ -14,6 +14,11 @@ fn lr() {
     assert_eq!(LR::default(), LR::Left(0));
 }
 
+#[impl_default(Single::A(Default::default()) where T: Default)]
+enum Single<T> {
+    A(T),
+}
+
 impl_scope! {
     #[impl_default(UnsafeNumber { as_u64: 0 })]
     union UnsafeNumber {
@@ -32,17 +37,17 @@ fn unsafe_number() {
 }
 
 impl_scope! {
-    #[impl_default]
-    struct Person {
+    #[impl_default(where T: trait)]
+    struct Person<T> {
         name: String = "Jane Doe".to_string(),
         age: u32 = 72,
-        occupation: String,
+        occupation: T,
     }
 }
 
 #[test]
 fn person() {
-    let person = Person::default();
+    let person = Person::<String>::default();
     assert_eq!(person.name, "Jane Doe");
     assert_eq!(person.age, 72);
     assert_eq!(person.occupation, "");


### PR DESCRIPTION
PR adds:

- Attrs expanded by `impl_scope` now require an explicit grouping token, just like `#[proc_macro_attribute]`
- `impl_default` now supports a where clause

Changelog for 0.2.0:

- Added `impl_scope!`
- Added `#[impl_default]`