### PR TITLE
Change sig of fn ScopeAttr::apply: replace two args with attr: Attribute

### DIFF
--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -20,7 +20,7 @@ mod scope;
 
 pub use default::{AttrImplDefault, ImplDefault};
 pub use for_deref::ForDeref;
-pub use scope::{parse_attr_group, Scope, ScopeAttr, ScopeItem};
+pub use scope::{Scope, ScopeAttr, ScopeItem};
 
 /// Simple, allocation-free path representation
 pub struct SimplePath(&'static [&'static str]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,9 +90,9 @@ use impl_tools_lib::{autoimpl, AttrImplDefault, ImplDefault, Scope, ScopeAttr};
 /// A where clause is optional: `#[impl_default(where BOUNDS)]`.
 #[proc_macro_attribute]
 #[proc_macro_error]
-pub fn impl_default(attr: TokenStream, item: TokenStream) -> TokenStream {
+pub fn impl_default(args: TokenStream, item: TokenStream) -> TokenStream {
     let mut toks = item.clone();
-    match syn::parse::<ImplDefault>(attr) {
+    match syn::parse::<ImplDefault>(args) {
         Ok(attr) => toks.extend(TokenStream::from(attr.expand(item.into()))),
         Err(err) => {
             emit_call_site_error!(err);


### PR DESCRIPTION
This allows better error messages when missing content at
end of input: https://github.com/dtolnay/syn/issues/1206

Also: remove fn parse_attr_group