### PR TITLE
Prepare 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.2] — 2022-09-17
+
+-   Correct release of 0.4.1 (which bumped the version of impl-tools without
+    bumping impl-tools-lib) (#18)
+-   Fix `#[autoimpl]` on traits for GATs and attributes on trait const/method/type items (#17)
+
 ## [0.4.1] — 2022-09-17
 
--   Fix `#[autoimpl]` on traits for GATs and attributes on trait const/method/type items (#17)
+No changes (prefer 0.4.2 instead).
 
 ## [0.4.0] — 2022-08-19
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "impl-tools"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2021"
 license = "MIT/Apache-2.0"
@@ -21,7 +21,7 @@ proc-macro-error = "1.0"
 version = "1.0.14"
 
 [dependencies.impl-tools-lib]
-version = "0.4.0"
+version = "0.4.2"
 path = "lib"
 
 [dev-dependencies]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "impl-tools-lib"
-version = "0.4.0"
+version = "0.4.2"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2021"
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
Corrects release since I failed to bump the version of `impl-tools-lib` required by `impl-tools` in #17.