### PR TITLE
[breaking] Support more traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ path = "lib"
 
 [dev-dependencies]
 doc-comment = "0.3.3"
+twox-hash = "1.6.3"
 
 [build-dependencies]
 autocfg = "1.1.0"

--- a/lib/src/autoimpl.rs
+++ b/lib/src/autoimpl.rs
@@ -264,7 +264,10 @@ impl ImplTraits {
         if !self.args.ignores.is_empty() {
             for (target, except_with) in not_supporting_ignore.into_iter() {
                 if let Some(path) = except_with {
-                    if impl_targets.iter().any(|(_span, target_impl)| path == target_impl.path()) {
+                    if impl_targets
+                        .iter()
+                        .any(|(_span, target_impl)| path == target_impl.path())
+                    {
                         continue;
                     }
                 }
@@ -359,7 +362,7 @@ impl ImplArgs {
         self.using.as_ref()
     }
 
-    /// Find find to "use", if any
+    /// Find field to "use", if any
     pub fn using_field<'b>(&self, fields: &'b Fields) -> Option<&'b Field> {
         match fields {
             Fields::Named(fields) => fields.named.iter().find(|field| match self.using {
@@ -379,6 +382,29 @@ impl ImplArgs {
                     })
             }
             Fields::Unit => None,
+        }
+    }
+
+    /// Call the given closure over all non-ignored fields
+    pub fn for_fields<'f>(&self, fields: &'f Fields, mut f: impl FnMut(Member, &'f Field)) {
+        match &fields {
+            Fields::Named(fields) => {
+                for field in fields.named.iter() {
+                    let member = Member::from(field.ident.clone().unwrap());
+                    if !self.ignore(&member) {
+                        f(member, field);
+                    }
+                }
+            }
+            Fields::Unnamed(fields) => {
+                for (i, field) in fields.unnamed.iter().enumerate() {
+                    let member = Member::from(Index::from(i));
+                    if !self.ignore(&member) {
+                        f(member, field);
+                    }
+                }
+            }
+            Fields::Unit => (),
         }
     }
 }

--- a/lib/src/autoimpl.rs
+++ b/lib/src/autoimpl.rs
@@ -25,6 +25,7 @@ pub const STD_IMPLS: &[&dyn ImplTrait] = &[
     &ImplClone,
     &ImplDebug,
     &ImplDefault,
+    &ImplPartialEq,
     &ImplBorrow,
     &ImplBorrowMut,
     &ImplAsRef,

--- a/lib/src/autoimpl.rs
+++ b/lib/src/autoimpl.rs
@@ -29,6 +29,7 @@ pub const STD_IMPLS: &[&dyn ImplTrait] = &[
     &ImplEq,
     &ImplPartialOrd,
     &ImplOrd,
+    &ImplHash,
     &ImplBorrow,
     &ImplBorrowMut,
     &ImplAsRef,

--- a/lib/src/autoimpl.rs
+++ b/lib/src/autoimpl.rs
@@ -82,6 +82,7 @@ pub trait ImplTrait {
         let wc = clause_to_toks(&args.clause, item_wc, &path);
 
         Ok(quote! {
+            #[automatically_derived]
             impl #impl_generics #path for #type_ident #ty_generics #wc {
                 #items
             }

--- a/lib/src/autoimpl.rs
+++ b/lib/src/autoimpl.rs
@@ -23,6 +23,7 @@ pub use impl_using::*;
 /// List of all builtin trait implementations
 pub const STD_IMPLS: &[&dyn ImplTrait] = &[
     &ImplClone,
+    &ImplCopy,
     &ImplDebug,
     &ImplDefault,
     &ImplPartialEq,

--- a/lib/src/autoimpl.rs
+++ b/lib/src/autoimpl.rs
@@ -93,7 +93,7 @@ pub trait ImplTrait {
     ///
     /// On success, this method returns the tuple `(trait_path, items)`. These
     /// are used to generate the following implementation:
-    /// ```
+    /// ```ignore
     /// impl #impl_generics #trait_path for #type_ident #ty_generics #where_clause {
     ///     #items
     /// }

--- a/lib/src/autoimpl.rs
+++ b/lib/src/autoimpl.rs
@@ -25,6 +25,10 @@ pub const STD_IMPLS: &[&dyn ImplTrait] = &[
     &ImplClone,
     &ImplDebug,
     &ImplDefault,
+    &ImplBorrow,
+    &ImplBorrowMut,
+    &ImplAsRef,
+    &ImplAsMut,
     &ImplDeref,
     &ImplDerefMut,
 ];

--- a/lib/src/autoimpl/impl_misc.rs
+++ b/lib/src/autoimpl/impl_misc.rs
@@ -294,3 +294,30 @@ impl ImplTrait for ImplOrd {
         Ok((quote! { ::core::cmp::Ord }, method))
     }
 }
+
+/// Implement [`core::hash::Hash`]
+pub struct ImplHash;
+impl ImplTrait for ImplHash {
+    fn path(&self) -> SimplePath {
+        SimplePath::new(&["", "core", "hash", "Hash"])
+    }
+
+    fn support_ignore(&self) -> bool {
+        true
+    }
+
+    fn struct_items(&self, item: &ItemStruct, args: &ImplArgs) -> Result<(Toks, Toks)> {
+        let mut toks = Toks::new();
+        args.for_fields_iter(item.fields.iter().enumerate().rev(), |member: Member, _| {
+            toks.append_all(quote! { ::core::hash::Hash::hash(&self.#member, state); });
+        });
+
+        let method = quote! {
+            #[inline]
+            fn hash<__H: ::core::hash::Hasher>(&self, state: &mut __H) {
+                #toks
+            }
+        };
+        Ok((quote! { ::core::hash::Hash }, method))
+    }
+}

--- a/lib/src/autoimpl/impl_misc.rs
+++ b/lib/src/autoimpl/impl_misc.rs
@@ -60,6 +60,22 @@ impl ImplTrait for ImplClone {
     }
 }
 
+/// Implement [`core::marker::Copy`]
+pub struct ImplCopy;
+impl ImplTrait for ImplCopy {
+    fn path(&self) -> SimplePath {
+        SimplePath::new(&["", "core", "marker", "Copy"])
+    }
+
+    fn allow_ignore_with(&self) -> Option<SimplePath> {
+        Some(SimplePath::new(&["", "core", "clone", "Clone"]))
+    }
+
+    fn struct_items(&self, _: &ItemStruct, _: &ImplArgs) -> Result<(Toks, Toks)> {
+        Ok((quote! { ::core::marker::Copy }, quote! {}))
+    }
+}
+
 /// Implement [`core::fmt::Debug`]
 pub struct ImplDebug;
 impl ImplTrait for ImplDebug {

--- a/lib/src/autoimpl/impl_misc.rs
+++ b/lib/src/autoimpl/impl_misc.rs
@@ -22,10 +22,6 @@ impl ImplTrait for ImplClone {
         true
     }
 
-    fn support_using(&self) -> bool {
-        false
-    }
-
     fn struct_items(&self, item: &ItemStruct, args: &ImplArgs) -> Result<(Toks, Toks)> {
         let type_ident = &item.ident;
         let inner = match &item.fields {
@@ -73,10 +69,6 @@ impl ImplTrait for ImplDebug {
 
     fn support_ignore(&self) -> bool {
         true
-    }
-
-    fn support_using(&self) -> bool {
-        false
     }
 
     fn struct_items(&self, item: &ItemStruct, args: &ImplArgs) -> Result<(Toks, Toks)> {
@@ -135,14 +127,6 @@ pub struct ImplDefault;
 impl ImplTrait for ImplDefault {
     fn path(&self) -> SimplePath {
         SimplePath::new(&["", "core", "default", "Default"])
-    }
-
-    fn support_ignore(&self) -> bool {
-        false
-    }
-
-    fn support_using(&self) -> bool {
-        false
     }
 
     fn struct_items(&self, item: &ItemStruct, _: &ImplArgs) -> Result<(Toks, Toks)> {

--- a/lib/src/autoimpl/impl_misc.rs
+++ b/lib/src/autoimpl/impl_misc.rs
@@ -213,3 +213,19 @@ impl ImplTrait for ImplPartialEq {
         Ok((quote! { ::core::cmp::PartialEq }, method))
     }
 }
+
+/// Implement [`core::cmp::Eq`]
+pub struct ImplEq;
+impl ImplTrait for ImplEq {
+    fn path(&self) -> SimplePath {
+        SimplePath::new(&["", "core", "cmp", "Eq"])
+    }
+
+    fn allow_ignore_with(&self) -> Option<SimplePath> {
+        Some(SimplePath::new(&["", "core", "cmp", "PartialEq"]))
+    }
+
+    fn struct_items(&self, _: &ItemStruct, _: &ImplArgs) -> Result<(Toks, Toks)> {
+        Ok((quote! { ::core::cmp::Eq }, quote! {}))
+    }
+}

--- a/lib/src/autoimpl/impl_misc.rs
+++ b/lib/src/autoimpl/impl_misc.rs
@@ -1,0 +1,173 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Miscellaneous impls
+
+use super::{ImplArgs, ImplTrait, Result};
+use crate::SimplePath;
+use proc_macro2::TokenStream;
+use quote::{quote, TokenStreamExt};
+use syn::{Fields, Index, ItemStruct};
+
+/// Implement [`core::clone::Clone`]
+pub struct ImplClone;
+impl ImplTrait for ImplClone {
+    fn path(&self) -> SimplePath {
+        SimplePath::new(&["", "core", "clone", "Clone"])
+    }
+
+    fn support_ignore(&self) -> bool {
+        true
+    }
+
+    fn support_using(&self) -> bool {
+        false
+    }
+
+    fn struct_items(&self, item: &ItemStruct, args: &ImplArgs) -> Result<TokenStream> {
+        let type_ident = &item.ident;
+        let inner = match &item.fields {
+            Fields::Named(fields) => {
+                let mut toks = TokenStream::new();
+                for field in fields.named.iter() {
+                    let ident = field.ident.as_ref().unwrap();
+                    if args.ignore_named(ident) {
+                        toks.append_all(quote! { #ident: Default::default(), });
+                    } else {
+                        toks.append_all(quote! { #ident: self.#ident.clone(), });
+                    }
+                }
+                quote! { #type_ident { #toks } }
+            }
+            Fields::Unnamed(fields) => {
+                let mut toks = TokenStream::new();
+                for i in 0..fields.unnamed.len() {
+                    let index = Index::from(i);
+                    if args.ignore_unnamed(&index) {
+                        toks.append_all(quote! { Default::default(), });
+                    } else {
+                        toks.append_all(quote! { self.#index.clone(), });
+                    }
+                }
+                quote! { #type_ident ( #toks ) }
+            }
+            Fields::Unit => quote! { #type_ident },
+        };
+        Ok(quote! {
+            fn clone(&self) -> Self {
+                #inner
+            }
+        })
+    }
+}
+
+/// Implement [`core::fmt::Debug`]
+pub struct ImplDebug;
+impl ImplTrait for ImplDebug {
+    fn path(&self) -> SimplePath {
+        SimplePath::new(&["", "core", "fmt", "Debug"])
+    }
+
+    fn support_ignore(&self) -> bool {
+        true
+    }
+
+    fn support_using(&self) -> bool {
+        false
+    }
+
+    fn struct_items(&self, item: &ItemStruct, args: &ImplArgs) -> Result<TokenStream> {
+        let type_name = item.ident.to_string();
+        let mut inner;
+        match &item.fields {
+            Fields::Named(fields) => {
+                inner = quote! { f.debug_struct(#type_name) };
+                let mut no_skips = true;
+                for field in fields.named.iter() {
+                    let ident = field.ident.as_ref().unwrap();
+                    if !args.ignore_named(ident) {
+                        let name = ident.to_string();
+                        inner.append_all(quote! {
+                            .field(#name, &self.#ident)
+                        });
+                    } else {
+                        no_skips = false;
+                    }
+                }
+                if no_skips {
+                    inner.append_all(quote! { .finish() });
+                } else {
+                    inner.append_all(quote! { .finish_non_exhaustive() });
+                };
+            }
+            Fields::Unnamed(fields) => {
+                inner = quote! { f.debug_tuple(#type_name) };
+                for i in 0..fields.unnamed.len() {
+                    let index = Index::from(i);
+                    if !args.ignore_unnamed(&index) {
+                        inner.append_all(quote! {
+                            .field(&self.#index)
+                        });
+                    } else {
+                        inner.append_all(quote! {
+                            .field(&format_args!("_"))
+                        });
+                    }
+                }
+                inner.append_all(quote! { .finish() });
+            }
+            Fields::Unit => inner = quote! { f.write_str(#type_name) },
+        };
+        Ok(quote! {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                #inner
+            }
+        })
+    }
+}
+
+/// Implement [`core::default::Default`]
+pub struct ImplDefault;
+impl ImplTrait for ImplDefault {
+    fn path(&self) -> SimplePath {
+        SimplePath::new(&["", "core", "default", "Default"])
+    }
+
+    fn support_ignore(&self) -> bool {
+        false
+    }
+
+    fn support_using(&self) -> bool {
+        false
+    }
+
+    fn struct_items(&self, item: &ItemStruct, _: &ImplArgs) -> Result<TokenStream> {
+        let type_ident = &item.ident;
+        let mut inner;
+        match &item.fields {
+            Fields::Named(fields) => {
+                inner = quote! {};
+                for field in fields.named.iter() {
+                    let ident = field.ident.as_ref().unwrap();
+                    inner.append_all(quote! { #ident: Default::default(), });
+                }
+                inner = quote! { #type_ident { #inner } };
+            }
+            Fields::Unnamed(fields) => {
+                inner = quote! {};
+                for _ in 0..fields.unnamed.len() {
+                    inner.append_all(quote! { Default::default(), });
+                }
+                inner = quote! { #type_ident(#inner) };
+            }
+            Fields::Unit => inner = quote! { #type_ident },
+        }
+        Ok(quote! {
+            fn default() -> Self {
+                #inner
+            }
+        })
+    }
+}

--- a/lib/src/autoimpl/impl_using.rs
+++ b/lib/src/autoimpl/impl_using.rs
@@ -1,0 +1,71 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Impls "using" a field
+
+use super::{Error, ImplArgs, ImplTrait, Result};
+use crate::SimplePath;
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::ItemStruct;
+
+/// Implement [`core::ops::Deref`]
+pub struct ImplDeref;
+impl ImplTrait for ImplDeref {
+    fn path(&self) -> SimplePath {
+        SimplePath::new(&["", "core", "ops", "Deref"])
+    }
+
+    fn support_ignore(&self) -> bool {
+        false
+    }
+
+    fn support_using(&self) -> bool {
+        true
+    }
+
+    fn struct_items(&self, item: &ItemStruct, args: &ImplArgs) -> Result<TokenStream> {
+        if let Some(field) = args.using_field(&item.fields) {
+            let ty = field.ty.clone();
+            let member = args.using_member().unwrap();
+            Ok(quote! {
+                type Target = #ty;
+                fn deref(&self) -> &Self::Target {
+                    &self.#member
+                }
+            })
+        } else {
+            Err(Error::RequireUsing)
+        }
+    }
+}
+
+/// Implement [`core::ops::DerefMut`]
+pub struct ImplDerefMut;
+impl ImplTrait for ImplDerefMut {
+    fn path(&self) -> SimplePath {
+        SimplePath::new(&["", "core", "ops", "DerefMut"])
+    }
+
+    fn support_ignore(&self) -> bool {
+        false
+    }
+
+    fn support_using(&self) -> bool {
+        true
+    }
+
+    fn struct_items(&self, _: &ItemStruct, args: &ImplArgs) -> Result<TokenStream> {
+        if let Some(member) = args.using_member() {
+            Ok(quote! {
+                fn deref_mut(&mut self) -> &mut Self::Target {
+                    &mut self.#member
+                }
+            })
+        } else {
+            Err(Error::RequireUsing)
+        }
+    }
+}

--- a/lib/src/autoimpl/impl_using.rs
+++ b/lib/src/autoimpl/impl_using.rs
@@ -18,10 +18,6 @@ impl ImplTrait for ImplBorrow {
         SimplePath::new(&["", "core", "borrow", "Borrow"])
     }
 
-    fn support_ignore(&self) -> bool {
-        false
-    }
-
     fn support_using(&self) -> bool {
         true
     }
@@ -47,10 +43,6 @@ pub struct ImplBorrowMut;
 impl ImplTrait for ImplBorrowMut {
     fn path(&self) -> SimplePath {
         SimplePath::new(&["", "core", "borrow", "BorrowMut"])
-    }
-
-    fn support_ignore(&self) -> bool {
-        false
     }
 
     fn support_using(&self) -> bool {
@@ -80,10 +72,6 @@ impl ImplTrait for ImplAsRef {
         SimplePath::new(&["", "core", "convert", "AsRef"])
     }
 
-    fn support_ignore(&self) -> bool {
-        false
-    }
-
     fn support_using(&self) -> bool {
         true
     }
@@ -109,10 +97,6 @@ pub struct ImplAsMut;
 impl ImplTrait for ImplAsMut {
     fn path(&self) -> SimplePath {
         SimplePath::new(&["", "core", "convert", "AsMut"])
-    }
-
-    fn support_ignore(&self) -> bool {
-        false
     }
 
     fn support_using(&self) -> bool {
@@ -142,10 +126,6 @@ impl ImplTrait for ImplDeref {
         SimplePath::new(&["", "core", "ops", "Deref"])
     }
 
-    fn support_ignore(&self) -> bool {
-        false
-    }
-
     fn support_using(&self) -> bool {
         true
     }
@@ -172,10 +152,6 @@ pub struct ImplDerefMut;
 impl ImplTrait for ImplDerefMut {
     fn path(&self) -> SimplePath {
         SimplePath::new(&["", "core", "ops", "DerefMut"])
-    }
-
-    fn support_ignore(&self) -> bool {
-        false
     }
 
     fn support_using(&self) -> bool {

--- a/lib/src/autoimpl/impl_using.rs
+++ b/lib/src/autoimpl/impl_using.rs
@@ -11,6 +11,130 @@ use proc_macro2::TokenStream as Toks;
 use quote::quote;
 use syn::ItemStruct;
 
+/// Implement [`core::borrow::Borrow`]
+pub struct ImplBorrow;
+impl ImplTrait for ImplBorrow {
+    fn path(&self) -> SimplePath {
+        SimplePath::new(&["", "core", "borrow", "Borrow"])
+    }
+
+    fn support_ignore(&self) -> bool {
+        false
+    }
+
+    fn support_using(&self) -> bool {
+        true
+    }
+
+    fn struct_items(&self, item: &ItemStruct, args: &ImplArgs) -> Result<(Toks, Toks)> {
+        if let Some(field) = args.using_field(&item.fields) {
+            let ty = field.ty.clone();
+            let member = args.using_member().unwrap();
+            let method = quote! {
+                fn borrow(&self) -> & #ty {
+                    &self.#member
+                }
+            };
+            Ok((quote! { ::core::borrow::Borrow<#ty> }, method))
+        } else {
+            Err(Error::RequireUsing)
+        }
+    }
+}
+
+/// Implement [`core::borrow::BorrowMut`]
+pub struct ImplBorrowMut;
+impl ImplTrait for ImplBorrowMut {
+    fn path(&self) -> SimplePath {
+        SimplePath::new(&["", "core", "borrow", "BorrowMut"])
+    }
+
+    fn support_ignore(&self) -> bool {
+        false
+    }
+
+    fn support_using(&self) -> bool {
+        true
+    }
+
+    fn struct_items(&self, item: &ItemStruct, args: &ImplArgs) -> Result<(Toks, Toks)> {
+        if let Some(field) = args.using_field(&item.fields) {
+            let ty = field.ty.clone();
+            let member = args.using_member().unwrap();
+            let method = quote! {
+                fn borrow_mut(&mut self) -> &mut #ty {
+                    &mut self.#member
+                }
+            };
+            Ok((quote! { ::core::borrow::BorrowMut<#ty> }, method))
+        } else {
+            Err(Error::RequireUsing)
+        }
+    }
+}
+
+/// Implement [`core::convert::AsRef`]
+pub struct ImplAsRef;
+impl ImplTrait for ImplAsRef {
+    fn path(&self) -> SimplePath {
+        SimplePath::new(&["", "core", "convert", "AsRef"])
+    }
+
+    fn support_ignore(&self) -> bool {
+        false
+    }
+
+    fn support_using(&self) -> bool {
+        true
+    }
+
+    fn struct_items(&self, item: &ItemStruct, args: &ImplArgs) -> Result<(Toks, Toks)> {
+        if let Some(field) = args.using_field(&item.fields) {
+            let ty = field.ty.clone();
+            let member = args.using_member().unwrap();
+            let method = quote! {
+                fn as_ref(&self) -> & #ty {
+                    &self.#member
+                }
+            };
+            Ok((quote! { ::core::convert::AsRef<#ty> }, method))
+        } else {
+            Err(Error::RequireUsing)
+        }
+    }
+}
+
+/// Implement [`core::convert::AsMut`]
+pub struct ImplAsMut;
+impl ImplTrait for ImplAsMut {
+    fn path(&self) -> SimplePath {
+        SimplePath::new(&["", "core", "convert", "AsMut"])
+    }
+
+    fn support_ignore(&self) -> bool {
+        false
+    }
+
+    fn support_using(&self) -> bool {
+        true
+    }
+
+    fn struct_items(&self, item: &ItemStruct, args: &ImplArgs) -> Result<(Toks, Toks)> {
+        if let Some(field) = args.using_field(&item.fields) {
+            let ty = field.ty.clone();
+            let member = args.using_member().unwrap();
+            let method = quote! {
+                fn as_mut(&mut self) -> &mut #ty {
+                    &mut self.#member
+                }
+            };
+            Ok((quote! { ::core::convert::AsMut<#ty> }, method))
+        } else {
+            Err(Error::RequireUsing)
+        }
+    }
+}
+
 /// Implement [`core::ops::Deref`]
 pub struct ImplDeref;
 impl ImplTrait for ImplDeref {

--- a/lib/src/default.rs
+++ b/lib/src/default.rs
@@ -73,6 +73,7 @@ impl ImplDefault {
         let expr = self.expr.unwrap();
 
         quote! {
+            #[automatically_derived]
             impl #impl_generics core::default::Default for #ident #ty_generics #wc {
                 fn default() -> Self {
                     #expr
@@ -141,6 +142,7 @@ impl ScopeAttr for AttrImplDefault {
             );
 
             scope.generated.push(quote! {
+                #[automatically_derived]
                 impl #impl_generics core::default::Default for #ident #ty_generics #wc {
                     fn default() -> Self {
                         #ident {

--- a/lib/src/for_deref.rs
+++ b/lib/src/for_deref.rs
@@ -255,6 +255,7 @@ impl ForDeref {
             }
 
             toks.append_all(quote! {
+                #[automatically_derived]
                 impl #impl_generics #trait_ty for #target #where_clause {
                     #impl_items
                 }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -26,6 +26,7 @@ pub use for_deref::ForDeref;
 pub use scope::{Scope, ScopeAttr, ScopeItem};
 
 /// Simple, allocation-free path representation
+#[derive(PartialEq, Eq)]
 pub struct SimplePath(&'static [&'static str]);
 
 impl SimplePath {

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -109,23 +109,3 @@ impl SimplePath {
         }
     }
 }
-
-mod printing {
-    use super::SimplePath;
-    use proc_macro2::{Ident, Span, TokenStream};
-    use quote::{quote, ToTokens, TokenStreamExt};
-
-    impl ToTokens for SimplePath {
-        fn to_tokens(&self, tokens: &mut TokenStream) {
-            let mut iter = self.0.iter();
-            let first = iter.next().unwrap();
-            if !first.is_empty() {
-                tokens.append(Ident::new(first, Span::call_site()));
-            }
-            for next in iter {
-                let ident = Ident::new(next, Span::call_site());
-                tokens.append_all(quote! { :: #ident });
-            }
-        }
-    }
-}

--- a/tests/autoimpl.rs
+++ b/tests/autoimpl.rs
@@ -101,11 +101,11 @@ fn pair() {
 }
 
 #[autoimpl(Clone, Debug)]
-#[autoimpl(PartialEq, Eq, PartialOrd, Ord, Hash ignore self.f)]
+#[autoimpl(PartialEq, Eq, PartialOrd, Ord, Hash ignore self._f)]
 struct MixedComponents {
     i: i32,
     s: &'static str,
-    f: fn() -> i32,
+    _f: fn() -> i32,
 }
 
 #[test]
@@ -115,7 +115,7 @@ fn mixed_components() {
     let a = MixedComponents {
         i: 31,
         s: "abc",
-        f: || 9,
+        _f: || 9,
     };
     assert_eq!(a, a);
     assert_eq!(a.cmp(&a), Ordering::Equal);
@@ -126,7 +126,7 @@ fn mixed_components() {
     let b = MixedComponents {
         i: 31,
         s: "abc",
-        f: || 14,
+        _f: || 14,
     };
     assert_eq!(a, b); // field f differs but is ignored
     assert_eq!(a.cmp(&b), Ordering::Equal);

--- a/tests/autoimpl.rs
+++ b/tests/autoimpl.rs
@@ -78,7 +78,7 @@ fn y() {
 }
 
 #[autoimpl(Clone, Debug)]
-#[autoimpl(PartialEq ignore self.f)]
+#[autoimpl(PartialEq, Eq ignore self.f)]
 struct MixedComponents {
     i: i32,
     s: &'static str,

--- a/tests/autoimpl.rs
+++ b/tests/autoimpl.rs
@@ -11,6 +11,7 @@ use core::ops::DerefMut;
 use impl_tools::autoimpl;
 
 fn test_has_clone(_: impl Clone) {}
+fn test_has_copy(_: impl Copy) {}
 
 #[autoimpl(std::clone::Clone, core::fmt::Debug)]
 struct Unit;
@@ -21,12 +22,13 @@ fn unit() {
     assert_eq!(format!("{:?}", Unit), "Unit");
 }
 
-#[autoimpl(Clone, Debug ignore self.1 where T: trait)]
+#[autoimpl(Copy, Clone, Debug ignore self.1 where T: trait)]
 struct Wrapper<T>(pub T, ());
 
 #[test]
 fn wrapper() {
     test_has_clone(Wrapper(0i32, ()));
+    test_has_copy(Wrapper("foo", ()));
     assert_eq!(format!("{:?}", Wrapper((), ())), "Wrapper((), _)");
 }
 

--- a/tests/autoimpl.rs
+++ b/tests/autoimpl.rs
@@ -76,3 +76,36 @@ fn y() {
     *y.as_mut() = 12;
     assert_eq!(y.as_ref(), &12);
 }
+
+#[autoimpl(Clone, Debug)]
+#[autoimpl(PartialEq ignore self.f)]
+struct MixedComponents {
+    i: i32,
+    s: &'static str,
+    f: fn() -> i32,
+}
+
+#[test]
+fn mixed_components() {
+    let a = MixedComponents {
+        i: 31,
+        s: "abc",
+        f: || 9,
+    };
+    assert_eq!(a, a);
+
+    let b = MixedComponents {
+        i: 31,
+        s: "abc",
+        f: || 14,
+    };
+    assert_eq!(a, b); // field f differs but is ignored
+
+    let mut c = a.clone();
+    c.i = 2;
+    assert!(a != c);
+
+    let mut d = a.clone();
+    d.s = "def";
+    assert!(a != d);
+}

--- a/tests/autoimpl.rs
+++ b/tests/autoimpl.rs
@@ -52,6 +52,8 @@ fn x() {
 }
 
 #[autoimpl(Deref, DerefMut using self.t)]
+#[autoimpl(Borrow, BorrowMut using self.t)]
+#[autoimpl(AsRef, AsMut using self.t)]
 struct Y<S, T> {
     _s: S,
     t: T,
@@ -59,12 +61,18 @@ struct Y<S, T> {
 
 #[test]
 fn y() {
+    use core::borrow::{Borrow, BorrowMut};
+    use core::ops::Deref;
+
     let mut y = Y { _s: (), t: 1i32 };
 
-    fn set(x: &mut i32) {
-        *x = 2;
-    }
-    set(y.deref_mut());
-
+    *y.deref_mut() = 2;
+    assert_eq!(y.deref(), &2);
     assert_eq!(y.t, 2);
+
+    *y.borrow_mut() = 15;
+    assert_eq!(Borrow::<i32>::borrow(&y), &15);
+
+    *y.as_mut() = 12;
+    assert_eq!(y.as_ref(), &12);
 }


### PR DESCRIPTION
Breaking change: `ImplTrait::struct_items` now returns the trait path in addition to impl items on success.