### PR TITLE
0.5.1 - for_deref: do not copy attributes from trait items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] — 2022-09-23
+
+-   Fix: do not copy attributes on trait items (#24)
+
 ## [0.5.0] — 2022-09-22
 
 -   `#[autoimpl]` on traits now merges trait generics with macro generics (#21)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "impl-tools"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2021"
 license = "MIT/Apache-2.0"
@@ -21,7 +21,7 @@ proc-macro-error = "1.0"
 version = "1.0.14"
 
 [dependencies.impl-tools-lib]
-version = "0.5.0"
+version = "0.5.1"
 path = "lib"
 
 [dev-dependencies]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "impl-tools-lib"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2021"
 license = "MIT/Apache-2.0"

--- a/lib/src/for_deref.rs
+++ b/lib/src/for_deref.rs
@@ -173,7 +173,6 @@ impl ForDeref {
             for item in &item.items {
                 match item {
                     TraitItem::Const(item) => {
-                        tokens.append_all(item.attrs.outer());
                         item.const_token.to_tokens(tokens);
                         item.ident.to_tokens(tokens);
                         item.colon_token.to_tokens(tokens);
@@ -202,7 +201,6 @@ impl ForDeref {
                             continue;
                         }
 
-                        tokens.append_all(item.attrs.outer());
                         item.sig.to_tokens(tokens);
 
                         let ident = &item.sig.ident;
@@ -222,7 +220,6 @@ impl ForDeref {
                             );
                         }
 
-                        tokens.append_all(item.attrs.outer());
                         item.type_token.to_tokens(tokens);
                         item.ident.to_tokens(tokens);
 


### PR DESCRIPTION
Something like this:
```rust
#[autoimpl(for<T: trait> &T)]
trait Foo {
    /// A useless method
    fn foo();
}
```
previously expanded to this:
```rust
#[automatically_derived]
impl<T: Foo> Foo for &T {
    /// A useless method
    fn foo() {
        <T as Foo>::foo()
    }
}
```
The doc-comment should definitely not be copied to the impl, nor should other attributes such as `#[inline]`.