### PR TITLE
0.5.2: add singleton! macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.2] — 2022-10-06
+
+-   Add `singleton!` macro (#25)
+
 ## [0.5.1] — 2022-09-23
 
 -   Fix: do not copy attributes on trait items (#24)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "impl-tools"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2021"
 license = "MIT/Apache-2.0"
@@ -21,7 +21,7 @@ proc-macro-error = "1.0"
 version = "1.0.14"
 
 [dependencies.impl-tools-lib]
-version = "0.5.1"
+version = "0.5.2"
 path = "lib"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -117,7 +117,29 @@ impl_tools::impl_scope! {
 ```
 
 Caveat: `rustfmt` won't currently touch the contents. Hopefully that
-[can be fixed](https://github.com/rust-lang/rustfmt/issues/5254)!
+[can be fixed](https://github.com/rust-lang/rustfmt/pull/5538)!
+
+### Singleton
+
+`singleton!` is a function-like macro to construct a single-use struct with
+custom implementations (similar: [RFC#2604](https://github.com/rust-lang/rfcs/pull/2604)).
+
+Example:
+```rust
+use std::fmt;
+fn main() {
+    let world = "world";
+    let says_hello_world = impl_tools::singleton! {
+        struct(&'static str = world);
+        impl fmt::Display for Self {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                write!(f, "hello {}", self.0)
+            }
+        }
+    };
+    assert_eq!(format!("{}", says_hello_world), "hello world");
+}
+```
 
 
 Extensibility

--- a/README.md
+++ b/README.md
@@ -71,12 +71,10 @@ fn main() {
 `#[impl_default]` implements `std::default::Default`:
 
 ```rust
-use impl_tools::{impl_default, impl_scope};
-
-#[impl_default(Tree::Ash)]
+#[impl_tools::impl_default(Tree::Ash)]
 enum Tree { Ash, Beech, Birch, Willow }
 
-impl_scope! {
+impl_tools::impl_scope! {
     #[impl_default]
     struct Copse {
         tree_type: Tree,
@@ -85,16 +83,17 @@ impl_scope! {
 }
 ```
 
+Note: `#[impl_default]` is matched within an `impl_scope!` regardless of imports.
+
 ### Impl Scope
 
 `impl_scope!` is a function-like macro used to define a type plus its
 implementations. It supports `impl Self` syntax:
 
 ```rust
-use impl_tools::impl_scope;
 use std::fmt::Display;
 
-impl_scope! {
+impl_tools::impl_scope! {
     /// I don't know why this exists
     pub struct NamedThing<T: Display, F> {
         name: T,

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "impl-tools-lib"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2021"
 license = "MIT/Apache-2.0"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -19,4 +19,4 @@ proc-macro-error = "1.0"
 version = "1.0.14"
 # We need 'extra-traits' for equality testing
 # We need 'full' for parsing macros within macro arguments
-features = ["extra-traits", "full"]
+features = ["extra-traits", "full", "visit", "visit-mut"]

--- a/lib/README.md
+++ b/lib/README.md
@@ -1,11 +1,13 @@
 Impl-tools library
 =======
 
-This is the library behind the [impl-tools](https://crates.io/crates/impl-tools) crate.
+This is the library behind the [impl-tools] crate.
 
-The only reason to use this library directly is to extend the impl-tools macros
-to support custom traits in `#[autoimpl]` or custom attributes evaluated from
-`impl_scope!`.
+This library may be used directly to write custom variants of the [impl-tools]
+macros, for example extending `#[autoimpl]` to support other traits or
+writing new attribute macros to be evaluated within a `impl_scope!`.
+
+[impl-tools]: https://crates.io/crates/impl-tools
 
 
 Copyright and Licence

--- a/lib/src/default.rs
+++ b/lib/src/default.rs
@@ -181,3 +181,13 @@ impl Parse for ImplDefault {
         })
     }
 }
+
+/// Helper fn which can be passed to [`Scope::apply_attrs`]
+///
+/// This optionally matches [`AttrImplDefault`].
+pub fn find_attr_impl_default(path: &syn::Path) -> Option<&'static dyn ScopeAttr> {
+    AttrImplDefault
+        .path()
+        .matches(path)
+        .then(|| &AttrImplDefault as &dyn ScopeAttr)
+}

--- a/lib/src/fields.rs
+++ b/lib/src/fields.rs
@@ -12,6 +12,17 @@ use syn::parse::{Parse, ParseStream, Result};
 use syn::punctuated::Punctuated;
 use syn::{token, Attribute, Expr, Ident, Token, Type, Visibility};
 
+/// Struct style: unit/tuple/regular
+#[derive(Debug)]
+pub enum StructStyle {
+    /// A unit struct (e.g. `struct Foo;`)
+    Unit(Token![;]),
+    /// A tuple struct (e.g. `struct Foo(f32, f32);`)
+    Tuple(token::Paren, Token![;]),
+    /// A regular struct (e.g. `struct Foo { x: f32, y: f32 }`)
+    Regular(token::Brace),
+}
+
 /// Data stored within an enum variant or struct.
 ///
 /// This is a variant of [`syn::Fields`] supporting field initializers.

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -20,10 +20,12 @@ pub mod fields;
 mod for_deref;
 pub mod generics;
 mod scope;
+mod singleton;
 
 pub use default::{find_attr_impl_default, AttrImplDefault, ImplDefault};
 pub use for_deref::ForDeref;
 pub use scope::{Scope, ScopeAttr, ScopeItem};
+pub use singleton::{Singleton, SingletonField, SingletonScope};
 
 /// Simple, allocation-free path representation
 #[derive(PartialEq, Eq)]

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -21,7 +21,7 @@ mod for_deref;
 pub mod generics;
 mod scope;
 
-pub use default::{AttrImplDefault, ImplDefault};
+pub use default::{find_attr_impl_default, AttrImplDefault, ImplDefault};
 pub use for_deref::ForDeref;
 pub use scope::{Scope, ScopeAttr, ScopeItem};
 

--- a/lib/src/singleton.rs
+++ b/lib/src/singleton.rs
@@ -1,0 +1,572 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+use crate::fields::{Field, Fields, FieldsNamed, FieldsUnnamed, StructStyle};
+use crate::{Scope, ScopeItem};
+use proc_macro2::{Span, TokenStream};
+use quote::{quote, ToTokens, TokenStreamExt};
+use std::fmt::Write;
+use syn::token::{Brace, Colon, Comma, Eq, Paren, Semi};
+use syn::{parse_quote, punctuated::Punctuated, spanned::Spanned};
+use syn::{Attribute, GenericParam, Generics, Ident, ItemImpl, Member, Token, Type, TypePath};
+
+/// A field of a [`Singleton`]
+#[derive(Debug)]
+pub struct SingletonField {
+    /// Field attributes
+    pub attrs: Vec<Attribute>,
+    /// Field visibility
+    pub vis: syn::Visibility,
+    /// Field identifier (regular structs only, and optional even there)
+    pub ident: Option<Ident>,
+    /// Separator between identifier and type
+    ///
+    /// This is present only given an explicit identifier *and* an explicit type.
+    pub colon_token: Option<Colon>,
+    /// Field type
+    ///
+    /// In case the type is omitted, this has value [`Type::Infer`].
+    pub ty: Type,
+    /// Optional non-default value assignment
+    pub assignment: Option<(Eq, syn::Expr)>,
+}
+
+/// A struct with a single instantiation
+///
+/// The singleton macro may be used to conveniently declare a struct's type,
+/// implementations and construct an instance.
+/// This struct represents the macro's input.
+#[derive(Debug)]
+pub struct Singleton {
+    /// Struct attributes
+    pub attrs: Vec<Attribute>,
+    /// `struct` token
+    pub token: Token![struct],
+    /// (Explicit) struct generics
+    ///
+    /// Note: the macro instantiated type may have extra generics.
+    pub generics: Generics,
+    /// Struct style: unit/tuple/regular
+    pub style: StructStyle,
+    /// Struct fields
+    pub fields: Punctuated<SingletonField, Comma>,
+    /// (Explicit) struct implementations
+    pub impls: Vec<ItemImpl>,
+}
+
+impl Singleton {
+    /// Convert to a [`SingletonScope`]
+    pub fn into_scope(mut self) -> SingletonScope {
+        // Used to make fresh identifiers for generic types
+        let mut name_buf = String::with_capacity(32);
+        let mut make_ident = move |args: std::fmt::Arguments, span| -> Ident {
+            name_buf.clear();
+            name_buf.write_fmt(args).unwrap();
+            Ident::new(&name_buf, span)
+        };
+
+        let mut fields = Punctuated::<Field, Comma>::new();
+        let mut field_val_toks = quote! {};
+
+        for (index, pair) in self.fields.into_pairs().enumerate() {
+            let (field, opt_comma) = pair.into_tuple();
+
+            let mut ident = field.ident.clone();
+            let ty = &field.ty;
+            let field_span = match field.assignment {
+                None => quote! { #ty }.span(),
+                Some((ref eq, ref expr)) => quote! { #ty #eq #expr }.span(),
+            };
+            let mem = match self.style {
+                StructStyle::Regular(_) => {
+                    let id = ident
+                        .unwrap_or_else(|| make_ident(format_args!("_field{index}"), field_span));
+                    ident = Some(id.clone());
+                    Member::Named(id)
+                }
+                StructStyle::Tuple(_, _) => Member::Unnamed(syn::Index {
+                    index: index as u32,
+                    span: field_span,
+                }),
+                _ => unreachable!(),
+            };
+            let ty_name = match ident {
+                None => format!("_Field{index}"),
+                Some(ref id) => {
+                    let ident = id.to_string();
+                    let mut buf = "_Field".to_string();
+                    buf.reserve(ident.len());
+                    let mut next_upper = true;
+                    for c in ident.chars() {
+                        if c == '_' {
+                            next_upper = true;
+                            continue;
+                        }
+
+                        if next_upper {
+                            buf.extend(c.to_uppercase());
+                            next_upper = false;
+                        } else {
+                            buf.push(c);
+                        }
+                    }
+                    buf
+                }
+            };
+
+            let ty: Type = match field.ty {
+                Type::ImplTrait(syn::TypeImplTrait { impl_token, bounds }) => {
+                    let span = quote! { #impl_token #bounds }.span();
+                    let ty = Ident::new(&ty_name, span);
+
+                    self.generics.params.push(parse_quote! { #ty: #bounds });
+
+                    Type::Path(TypePath {
+                        qself: None,
+                        path: ty.into(),
+                    })
+                }
+                Type::Infer(infer_token) => {
+                    let ty = Ident::new(&ty_name, infer_token.span());
+                    self.generics.params.push(parse_quote! { #ty });
+
+                    Type::Path(TypePath {
+                        qself: None,
+                        path: ty.into(),
+                    })
+                }
+                mut ty => {
+                    struct ReplaceInfers<'a, F: FnMut(std::fmt::Arguments, Span) -> Ident> {
+                        index: usize,
+                        params: Vec<GenericParam>,
+                        make_ident: &'a mut F,
+                        ty_name: &'a str,
+                    }
+                    let mut replacer = ReplaceInfers {
+                        index: 0,
+                        params: vec![],
+                        make_ident: &mut make_ident,
+                        ty_name: &ty_name,
+                    };
+
+                    impl<'a, F: FnMut(std::fmt::Arguments, Span) -> Ident> syn::visit_mut::VisitMut
+                        for ReplaceInfers<'a, F>
+                    {
+                        fn visit_type_mut(&mut self, node: &mut Type) {
+                            let (span, bounds) = match node {
+                                Type::ImplTrait(syn::TypeImplTrait { impl_token, bounds }) => {
+                                    (impl_token.span, std::mem::take(bounds))
+                                }
+                                Type::Infer(infer) => (infer.span(), Punctuated::new()),
+                                _ => return,
+                            };
+
+                            let ident = (self.make_ident)(
+                                format_args!("{}{}", self.ty_name, self.index),
+                                span,
+                            );
+                            self.index += 1;
+
+                            self.params.push(GenericParam::Type(syn::TypeParam {
+                                attrs: vec![],
+                                ident: ident.clone(),
+                                colon_token: Some(Default::default()),
+                                bounds,
+                                eq_token: None,
+                                default: None,
+                            }));
+
+                            *node = Type::Path(TypePath {
+                                qself: None,
+                                path: ident.into(),
+                            });
+                        }
+                    }
+                    syn::visit_mut::visit_type_mut(&mut replacer, &mut ty);
+
+                    self.generics.params.extend(replacer.params);
+                    ty
+                }
+            };
+
+            if let Some((_, ref value)) = field.assignment {
+                field_val_toks.append_all(quote! { #mem: #value, });
+            } else {
+                field_val_toks.append_all(quote! { #mem: Default::default(), });
+            }
+
+            fields.push_value(Field {
+                attrs: field.attrs,
+                vis: field.vis,
+                ident,
+                colon_token: field.colon_token.or_else(|| Some(Default::default())),
+                ty,
+                assign: None,
+            });
+            if let Some(comma) = opt_comma {
+                fields.push_punct(comma);
+            }
+        }
+
+        let (fields, semi) = match self.style {
+            StructStyle::Unit(semi) => (Fields::Unit, Some(semi)),
+            StructStyle::Regular(brace_token) => (
+                Fields::Named(FieldsNamed {
+                    brace_token,
+                    fields,
+                }),
+                None,
+            ),
+            StructStyle::Tuple(paren_token, semi) => (
+                Fields::Unnamed(FieldsUnnamed {
+                    paren_token,
+                    fields,
+                }),
+                Some(semi),
+            ),
+        };
+
+        let scope = Scope {
+            attrs: self.attrs,
+            vis: syn::Visibility::Inherited,
+            ident: parse_quote! { _Singleton },
+            generics: self.generics,
+            item: ScopeItem::Struct {
+                token: self.token,
+                fields,
+            },
+            semi,
+            impls: self.impls,
+            generated: vec![],
+        };
+
+        SingletonScope(scope, field_val_toks)
+    }
+}
+
+/// A [`Scope`] plus field values
+///
+/// This supports dereference to a [`Scope`], allowing macro expansion via
+/// [`Scope::apply_attrs`] and other manipulation.
+///
+/// Tokens may be generated by [`Self::expand`].
+#[derive(Debug)]
+pub struct SingletonScope(Scope, TokenStream);
+
+impl std::ops::Deref for SingletonScope {
+    type Target = Scope;
+    fn deref(&self) -> &Scope {
+        &self.0
+    }
+}
+impl std::ops::DerefMut for SingletonScope {
+    fn deref_mut(&mut self) -> &mut Scope {
+        &mut self.0
+    }
+}
+
+impl SingletonScope {
+    /// Generate the [`TokenStream`]
+    ///
+    /// This is a convenience function. It is valid to, instead, (1) call
+    /// [`Scope::expand_impl_self`] on self, then (2) use the [`ToTokens`]
+    /// impl on `Scope`.
+    pub fn expand(mut self) -> TokenStream {
+        self.expand_impl_self();
+        self.into_token_stream()
+    }
+}
+
+impl ToTokens for SingletonScope {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let scope = &self.0;
+        let field_val_toks = &self.1;
+
+        tokens.append_all(quote! {
+            {
+                #scope
+
+                _Singleton {
+                    #field_val_toks
+                }
+            }
+        });
+    }
+}
+
+mod parsing {
+    use super::*;
+    use proc_macro_error::abort;
+    use syn::parse::{Error, Parse, ParseStream, Result};
+    use syn::{braced, bracketed, parenthesized};
+
+    fn parse_attrs_inner(input: ParseStream, attrs: &mut Vec<Attribute>) -> Result<()> {
+        while input.peek(Token![#]) && input.peek2(Token![!]) {
+            let pound_token = input.parse()?;
+            let style = syn::AttrStyle::Inner(input.parse()?);
+            let content;
+            let bracket_token = bracketed!(content in input);
+            let path = content.call(syn::Path::parse_mod_style)?;
+            let tokens = content.parse()?;
+            attrs.push(Attribute {
+                pound_token,
+                style,
+                bracket_token,
+                path,
+                tokens,
+            });
+        }
+        Ok(())
+    }
+
+    fn parse_impl(in_ident: Option<&Ident>, input: ParseStream) -> Result<ItemImpl> {
+        let mut attrs = input.call(Attribute::parse_outer)?;
+        let defaultness: Option<Token![default]> = input.parse()?;
+        let unsafety: Option<Token![unsafe]> = input.parse()?;
+        let impl_token: Token![impl] = input.parse()?;
+
+        let has_generics = input.peek(Token![<])
+            && (input.peek2(Token![>])
+                || input.peek2(Token![#])
+                || (input.peek2(Ident) || input.peek2(syn::Lifetime))
+                    && (input.peek3(Token![:])
+                        || input.peek3(Token![,])
+                        || input.peek3(Token![>])
+                        || input.peek3(Token![=]))
+                || input.peek2(Token![const]));
+        let mut generics: Generics = if has_generics {
+            input.parse()?
+        } else {
+            Generics::default()
+        };
+
+        let mut first_ty: Type = input.parse()?;
+        let self_ty: Type;
+        let trait_;
+
+        let is_impl_for = input.peek(Token![for]);
+        if is_impl_for {
+            let for_token: Token![for] = input.parse()?;
+            let mut first_ty_ref = &first_ty;
+            while let Type::Group(ty) = first_ty_ref {
+                first_ty_ref = &ty.elem;
+            }
+            if let Type::Path(_) = first_ty_ref {
+                while let Type::Group(ty) = first_ty {
+                    first_ty = *ty.elem;
+                }
+                if let Type::Path(TypePath { qself: None, path }) = first_ty {
+                    trait_ = Some((None, path, for_token));
+                } else {
+                    unreachable!();
+                }
+            } else {
+                return Err(Error::new(for_token.span(), "for without target trait"));
+            }
+            self_ty = input.parse()?;
+        } else {
+            trait_ = None;
+            self_ty = first_ty;
+        }
+
+        generics.where_clause = input.parse()?;
+
+        if self_ty != parse_quote! { Self } {
+            if let Some(ident) = in_ident {
+                if !matches!(self_ty, Type::Path(TypePath {
+                    qself: None,
+                    path: syn::Path {
+                        leading_colon: None,
+                        ref segments,
+                    }
+                }) if segments.len() == 1 && segments.first().unwrap().ident == *ident)
+                {
+                    abort!(
+                        self_ty.span(),
+                        format!(
+                            "expected `Self` or `{0}` or `{0}<...>` or `Trait for Self`, etc",
+                            ident
+                        )
+                    );
+                }
+            } else {
+                abort!(self_ty.span(), "expected `Self` or `Trait for Self`");
+            }
+        }
+
+        let content;
+        let brace_token = braced!(content in input);
+        parse_attrs_inner(&content, &mut attrs)?;
+
+        let mut items = Vec::new();
+        while !content.is_empty() {
+            items.push(content.parse()?);
+        }
+
+        Ok(ItemImpl {
+            attrs,
+            defaultness,
+            unsafety,
+            impl_token,
+            generics,
+            trait_,
+            self_ty: Box::new(self_ty),
+            brace_token,
+            items,
+        })
+    }
+
+    impl SingletonField {
+        fn check_is_fixed(ty: &Type, input_span: Span) -> Result<()> {
+            let is_fixed = match ty {
+                Type::ImplTrait(_) | Type::Infer(_) => false,
+                ty => {
+                    struct IsFixed(bool);
+                    let mut checker = IsFixed(true);
+
+                    impl<'ast> syn::visit::Visit<'ast> for IsFixed {
+                        fn visit_type(&mut self, node: &'ast Type) {
+                            if matches!(node, Type::ImplTrait(_) | Type::Infer(_)) {
+                                self.0 = false;
+                            }
+                        }
+                    }
+                    syn::visit::visit_type(&mut checker, ty);
+
+                    checker.0
+                }
+            };
+
+            if is_fixed {
+                Ok(())
+            } else {
+                Err(Error::new(
+                    input_span,
+                    "require either a fixed type or a value assignment",
+                ))
+            }
+        }
+
+        fn parse_named(input: ParseStream) -> Result<Self> {
+            let attrs = input.call(Attribute::parse_outer)?;
+            let vis = input.parse()?;
+
+            let ident = if input.peek(Token![_]) {
+                let _: Token![_] = input.parse()?;
+                None
+            } else {
+                Some(input.parse::<Ident>()?)
+            };
+
+            let mut colon_token = None;
+
+            // Note: Colon matches `::` but that results in confusing error messages
+            let ty = if input.peek(Colon) && !input.peek2(Colon) {
+                colon_token = Some(input.parse()?);
+                input.parse()?
+            } else {
+                parse_quote! { _ }
+            };
+
+            let mut assignment = None;
+            if let Ok(eq) = input.parse::<Eq>() {
+                assignment = Some((eq, input.parse()?));
+            } else {
+                Self::check_is_fixed(&ty, input.span())?;
+            }
+
+            Ok(SingletonField {
+                attrs,
+                vis,
+                ident,
+                colon_token,
+                ty,
+                assignment,
+            })
+        }
+
+        fn parse_unnamed(input: ParseStream) -> Result<Self> {
+            let attrs = input.call(Attribute::parse_outer)?;
+            let vis = input.parse()?;
+
+            let ty = input.parse()?;
+
+            let mut assignment = None;
+            if let Ok(eq) = input.parse::<Eq>() {
+                assignment = Some((eq, input.parse()?));
+            } else {
+                Self::check_is_fixed(&ty, input.span())?;
+            }
+
+            Ok(SingletonField {
+                attrs,
+                vis,
+                ident: None,
+                colon_token: None,
+                ty,
+                assignment,
+            })
+        }
+    }
+
+    impl Parse for Singleton {
+        fn parse(input: ParseStream) -> Result<Self> {
+            let attrs = input.call(Attribute::parse_outer)?;
+            let token = input.parse::<Token![struct]>()?;
+
+            let mut generics = input.parse::<Generics>()?;
+
+            let mut lookahead = input.lookahead1();
+            if lookahead.peek(Token![where]) {
+                generics.where_clause = Some(input.parse()?);
+                lookahead = input.lookahead1();
+            }
+
+            let style;
+            let fields;
+            if generics.where_clause.is_none() && lookahead.peek(Paren) {
+                let content;
+                let paren_token = parenthesized!(content in input);
+                fields = content.parse_terminated(SingletonField::parse_unnamed)?;
+
+                lookahead = input.lookahead1();
+                if lookahead.peek(Token![where]) {
+                    generics.where_clause = Some(input.parse()?);
+                    lookahead = input.lookahead1();
+                }
+
+                if lookahead.peek(Semi) {
+                    style = StructStyle::Tuple(paren_token, input.parse()?);
+                } else {
+                    return Err(lookahead.error());
+                }
+            } else if lookahead.peek(Brace) {
+                let content;
+                let brace_token = braced!(content in input);
+                style = StructStyle::Regular(brace_token);
+                fields = content.parse_terminated(SingletonField::parse_named)?;
+            } else if lookahead.peek(Semi) {
+                style = StructStyle::Unit(input.parse()?);
+                fields = Punctuated::new();
+            } else {
+                return Err(lookahead.error());
+            }
+
+            let mut impls = Vec::new();
+            while !input.is_empty() {
+                impls.push(parse_impl(None, input)?);
+            }
+
+            Ok(Singleton {
+                attrs,
+                token,
+                generics,
+                style,
+                fields,
+                impls,
+            })
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,10 @@
 //! -   Evaluation of advanced attribute macros, which may use field
 //!     initializers and read/write other impls within the scope
 //!
+//! `singleton!` is a function-like macro used to define and instantiate a
+//! unique (single-use) type. It supports everything supported by `impl_scope!`
+//! plus field initializers and (limited) automatic typing of fields.
+//!
 //! User-extensions to both `#[autoimpl]` and `impl_scope!` are possible, by
 //! writing your own proc-macro crate depending on
 //! [impl-tools-lib](https://crates.io/crates/impl-tools-lib).
@@ -313,6 +317,16 @@ pub fn autoimpl(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// Generic parameters from the type are included implicitly with the first form.
 /// Additional generic parameters and where clauses are supported (parameters
 /// and bounds are merged).
+///
+/// ## User-defined attributes
+///
+/// The following attributes are matched within `impl_scope!`, regardless of imports:
+///
+/// -   [`macro@impl_default`]: matches `#[impl_default]`
+///
+/// Note: matching these macros within `impl_scope!` does not use path resolution.
+/// Using `#[impl_tools::impl_default]` will resolve the variant of this
+/// macro which *doesn't support* field initializers.
 ///
 /// ## Example
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,15 +290,25 @@ pub fn autoimpl(attr: TokenStream, item: TokenStream) -> TokenStream {
 
 /// Scope supporting `impl Self` and advanced attribute macros
 ///
-/// This macro has three raisons d'être:
-///
-/// -   To support `impl Self` syntax
-/// -   To allow field initializers, as used by [`macro@impl_default`]
-/// -   To allow user-defined attribute macros to read/write other impls within
-///     the `impl_scope`
+/// This macro facilitates definition of a type (struct, enum or union) plus
+/// implementations via `impl Self { .. }` syntax: `Self` is expanded to the
+/// type's name, including generics and bounds (as defined on the type).
 ///
 /// Caveat: `rustfmt` can not yet format contents (see
-/// [rustfmt#5254](https://github.com/rust-lang/rustfmt/issues/5254)).
+/// [rustfmt#5254](https://github.com/rust-lang/rustfmt/issues/5254),
+/// [rustfmt#5538](https://github.com/rust-lang/rustfmt/pull/5538)).
+///
+/// ## Special attribute macros
+///
+/// Additionally, `impl_scope!` supports special attribute macros evaluated
+/// within its scope:
+///
+/// -   [`#[impl_default]`](macro@impl_default): implement [`Default`] using
+///     field initializers (which are not legal syntax outside of `impl_scope!`)
+///
+/// Note: matching these macros within `impl_scope!` does not use path
+/// resolution. Using `#[impl_tools::impl_default]` would resolve the variant
+/// of this macro which *doesn't support* field initializers.
 ///
 /// ## Syntax
 ///
@@ -317,16 +327,6 @@ pub fn autoimpl(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// Generic parameters from the type are included implicitly with the first form.
 /// Additional generic parameters and where clauses are supported (parameters
 /// and bounds are merged).
-///
-/// ## User-defined attributes
-///
-/// The following attributes are matched within `impl_scope!`, regardless of imports:
-///
-/// -   [`macro@impl_default`]: matches `#[impl_default]`
-///
-/// Note: matching these macros within `impl_scope!` does not use path resolution.
-/// Using `#[impl_tools::impl_default]` will resolve the variant of this
-/// macro which *doesn't support* field initializers.
 ///
 /// ## Example
 ///


### PR DESCRIPTION
A new macro ported from `kas-macros`:

```rust
use std::fmt;
fn main() {
    let world = "world";
    let says_hello_world = impl_tools::singleton! {
        struct(&'static str = world);
        impl fmt::Display for Self {
            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                write!(f, "hello {}", self.0)
            }
        }
    };
    assert_eq!(format!("{}", says_hello_world), "hello world");
}
```