### PR TITLE
0.6: support Deref<Target = T>; new-type pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] — 2022-11-17
+
+-   Add `ImplTrait::support_path_args`, `ImplArgs::path_args` (#26)
+-   Path args: support `Deref<Target = Foo>` (#26)
+
 ## [0.5.2] — 2022-10-06
 
 -   Add `singleton!` macro (#25)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "impl-tools"
-version = "0.5.2"
+version = "0.6.0"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2021"
 license = "MIT/Apache-2.0"
@@ -21,7 +21,7 @@ proc-macro-error = "1.0"
 version = "1.0.14"
 
 [dependencies.impl-tools-lib]
-version = "0.5.2"
+version = "0.6.0"
 path = "lib"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -66,6 +66,28 @@ fn main() {
 }
 ```
 
+#### New-type wrappers
+
+A combination of `Deref` on the new-type and trait-reimplementation on the
+trait allows succinct new-type patterns:
+
+```rust
+use impl_tools::autoimpl;
+
+#[autoimpl(for<T: trait> &T, &mut T)]
+trait Foo {
+    fn success(&self) -> bool;
+}
+
+#[autoimpl(Deref, DerefMut using self.0)]
+struct NewFoo<T: Foo>(T);
+
+// NewFoo now supports `Deref<Target = T>` and `&T` supports `Foo`.
+// Effectively, `NewFoo` supports `Foo`.
+// Works for FooRef<'a>(&'a dyn Foo) too; see tests/newtype.rs
+```
+
+
 ### Impl Default
 
 `#[impl_default]` implements `std::default::Default`:

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "impl-tools-lib"
-version = "0.5.2"
+version = "0.6.0"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2021"
 license = "MIT/Apache-2.0"

--- a/lib/src/autoimpl.rs
+++ b/lib/src/autoimpl.rs
@@ -49,7 +49,7 @@ pub trait ImplTrait {
     fn path(&self) -> SimplePath;
 
     /// True if this target supports path arguments
-    fn support_path_args(&self) -> bool {
+    fn support_path_arguments(&self) -> bool {
         false
     }
 
@@ -141,7 +141,7 @@ pub enum Error {
     /// Emit an error with the given `span` and `message`
     WithSpan(Span, &'static str),
     /// Emit an error regarding path arguments
-    PathArgs(&'static str),
+    PathArguments(&'static str),
 }
 
 /// Result type
@@ -220,7 +220,7 @@ mod parsing {
             }
 
             let args = ImplArgs {
-                path_args: PathArguments::None,
+                path_arguments: PathArguments::None,
                 ignores,
                 using,
                 clause,
@@ -283,7 +283,7 @@ impl ImplTraits {
             if !target_impl.support_using() {
                 not_supporting_using.push(target.clone());
             }
-            if !(path_args.is_empty() || target_impl.support_path_args()) {
+            if !(path_args.is_empty() || target_impl.support_path_arguments()) {
                 emit_error!(
                     target_span,
                     "target {} does not support path arguments",
@@ -344,7 +344,7 @@ impl ImplTraits {
 
         for (span, target, path_args) in impl_targets.drain(..) {
             let path_args_span = path_args.span();
-            args.path_args = path_args;
+            args.path_arguments = path_args;
             match target.struct_impl(&item, &args) {
                 Ok(items) => toks.append_all(items),
                 Err(error) => match error {
@@ -353,7 +353,7 @@ impl ImplTraits {
                     }
                     Error::CallSite(msg) => emit_error!(span, msg),
                     Error::WithSpan(span, msg) => emit_error!(span, msg),
-                    Error::PathArgs(msg) => emit_error!(path_args_span, msg),
+                    Error::PathArguments(msg) => emit_error!(path_args_span, msg),
                 },
             }
         }
@@ -367,7 +367,7 @@ pub struct ImplArgs {
     ///
     /// Example: if the target is `Deref<Target = T>`, this is `<Target = T>`.
     /// This is always empty unless [`ImplTrait::support_path_args`] returns true.
-    pub path_args: PathArguments,
+    pub path_arguments: PathArguments,
     /// Fields ignored in attribute
     pub ignores: Vec<Member>,
     /// Field specified to 'use' in attribute

--- a/lib/src/autoimpl/impl_using.rs
+++ b/lib/src/autoimpl/impl_using.rs
@@ -126,7 +126,7 @@ impl ImplTrait for ImplDeref {
         SimplePath::new(&["", "core", "ops", "Deref"])
     }
 
-    fn support_path_args(&self) -> bool {
+    fn support_path_arguments(&self) -> bool {
         true
     }
 
@@ -136,7 +136,7 @@ impl ImplTrait for ImplDeref {
 
     fn struct_items(&self, item: &ItemStruct, args: &ImplArgs) -> Result<(Toks, Toks)> {
         if let Some(field) = args.using_field(&item.fields) {
-            let target = match args.path_args {
+            let target = match args.path_arguments {
                 PathArguments::None => field.ty.clone(),
                 PathArguments::AngleBracketed(syn::AngleBracketedGenericArguments {
                     ref args,
@@ -150,14 +150,14 @@ impl ImplTrait for ImplDeref {
                                 continue;
                             }
                         }
-                        return Err(Error::PathArgs("expected `<Target = ..>`"));
+                        return Err(Error::PathArguments("expected `<Target = ..>`"));
                     }
                     match result {
                         Some(r) => r,
-                        None => return Err(Error::PathArgs("expected `<Target = ..>`")),
+                        None => return Err(Error::PathArguments("expected `<Target = ..>`")),
                     }
                 }
-                PathArguments::Parenthesized(_) => return Err(Error::PathArgs("unexpected")),
+                PathArguments::Parenthesized(_) => return Err(Error::PathArguments("unexpected")),
             };
 
             let member = args.using_member().unwrap();

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -31,6 +31,19 @@ pub use singleton::{Singleton, SingletonField, SingletonScope};
 #[derive(PartialEq, Eq)]
 pub struct SimplePath(&'static [&'static str]);
 
+impl std::fmt::Display for SimplePath {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+        if !self.0.is_empty() {
+            write!(f, "{}", self.0[0])?;
+            for component in &self.0[1..] {
+                write!(f, "::{}", component)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
 impl SimplePath {
     /// Construct, verifying validity
     ///

--- a/tests/newtype.rs
+++ b/tests/newtype.rs
@@ -1,6 +1,8 @@
 //! Test implementing traits over newtype wrappers
 
 use impl_tools::autoimpl;
+use std::rc::Rc;
+use std::sync::Arc;
 
 #[autoimpl(for<T: trait> &T, &mut T, Box<T>)]
 trait Foo {
@@ -14,23 +16,63 @@ impl Foo for S {
     }
 }
 
-#[autoimpl(Deref, DerefMut using self.0)]
-struct NewFoo<T: Foo>(T);
-
-#[autoimpl(Deref, DerefMut using self.0)]
-struct FooRef<'a>(&'a dyn Foo);
-
-#[autoimpl(Deref, DerefMut using self.0)]
-struct FooRefMut<'a>(&'a mut dyn Foo);
-
-#[autoimpl(Deref, DerefMut using self.0)]
-struct BoxFoo<T: Foo>(Box<T>);
+#[test]
+fn direct() {
+    assert!(S.success());
+}
 
 #[test]
-fn foo() {
-    assert!(S.success());
-    assert!(NewFoo(S).success());
-    assert!(FooRef(&S).success());
-    assert!(FooRefMut(&mut S).success());
-    assert!(BoxFoo(Box::new(S)).success());
+fn new_foo() {
+    #[autoimpl(Deref, DerefMut using self.0)]
+    struct NewType<T: Foo>(T);
+
+    assert!(NewType(S).success());
+}
+
+#[test]
+fn new_foo_ref() {
+    #[autoimpl(Deref, DerefMut using self.0)]
+    struct NewType<'a>(&'a dyn Foo);
+
+    assert!(NewType(&S).success());
+}
+
+#[test]
+fn new_foo_ref_mut() {
+    #[autoimpl(Deref, DerefMut using self.0)]
+    struct NewType<'a>(&'a mut dyn Foo);
+
+    assert!(NewType(&mut S).success());
+}
+
+#[test]
+fn new_foo_box() {
+    #[autoimpl(Deref, DerefMut using self.0)]
+    struct NewType<T: Foo>(Box<T>);
+
+    assert!(NewType(Box::new(S)).success());
+}
+
+#[test]
+fn new_foo_box_dyn() {
+    #[autoimpl(Deref, DerefMut using self.0)]
+    struct NewType(Box<dyn Foo>);
+
+    assert!(NewType(Box::new(S)).success());
+}
+
+#[test]
+fn new_foo_rc_dyn() {
+    #[autoimpl(Deref, DerefMut using self.0)]
+    struct NewType(Rc<dyn Foo>);
+
+    assert!(NewType(Rc::new(S)).success());
+}
+
+#[test]
+fn new_foo_arc_dyn() {
+    #[autoimpl(Deref, DerefMut using self.0)]
+    struct NewType(Arc<dyn Foo + Send + Sync>);
+
+    assert!(NewType(Arc::new(S)).success());
 }

--- a/tests/newtype.rs
+++ b/tests/newtype.rs
@@ -8,6 +8,8 @@ mod inner {
     use impl_tools::autoimpl;
 
     #[autoimpl(for<T: trait + ?Sized> &T, &mut T, Box<T>, Rc<T>, Arc<T>)]
+    // Optionally, we can also implement Foo directly for these types:
+    // #[autoimpl(for<T: trait> NewFoo<T>, BoxFoo<T>)]
     pub trait Foo {
         fn is_true(&self) -> bool;
     }

--- a/tests/newtype.rs
+++ b/tests/newtype.rs
@@ -1,0 +1,36 @@
+//! Test implementing traits over newtype wrappers
+
+use impl_tools::autoimpl;
+
+#[autoimpl(for<T: trait> &T, &mut T, Box<T>)]
+trait Foo {
+    fn success(&self) -> bool;
+}
+
+struct S;
+impl Foo for S {
+    fn success(&self) -> bool {
+        true
+    }
+}
+
+#[autoimpl(Deref, DerefMut using self.0)]
+struct NewFoo<T: Foo>(T);
+
+#[autoimpl(Deref, DerefMut using self.0)]
+struct FooRef<'a>(&'a dyn Foo);
+
+#[autoimpl(Deref, DerefMut using self.0)]
+struct FooRefMut<'a>(&'a mut dyn Foo);
+
+#[autoimpl(Deref, DerefMut using self.0)]
+struct BoxFoo<T: Foo>(Box<T>);
+
+#[test]
+fn foo() {
+    assert!(S.success());
+    assert!(NewFoo(S).success());
+    assert!(FooRef(&S).success());
+    assert!(FooRefMut(&mut S).success());
+    assert!(BoxFoo(Box::new(S)).success());
+}


### PR DESCRIPTION
Closes #14. I think we don't actually need any new functionality?