### PR TITLE
Support autoimpl for enums

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: "1.56.0"
+          toolchain: "1.58.0"
           override: true
           components: clippy
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] — 2022-02-07
+
+-   Bump MSRV to 1.58.0 (#31)
+-   `#[autoimpl(Clone, Debug, PartialEq, Eq, Hash)]` now all support enums
+    (with optional `where` clause, without `ignore` clauses) (#31)
+-   Add `impl_tools_lib::ImplTrait::enum_impl`, `enum_items` with default impls;
+    `ImplTraits::expand` now supports enums (#31)
+-   Add `impl_tools_lib::Ident_formatter` utility (#31)
+
+Note: `PartialOrd, Ord` *could* now support enums (unimplemented). `ignore` and
+`using` clauses are deliberately not supported (due to syntactic ambiguity).
+
 ## [0.6.2], `impl-tools-lib` [0.7.1] — 2022-12-16
 
 -   Fix `#[autoimpl]` on traits: copy `#[cfg(..)]` attributes (#30)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "impl-tools"
-version = "0.6.2"
+version = "0.8.0"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2021"
 license = "MIT/Apache-2.0"
@@ -21,7 +21,7 @@ proc-macro-error = "1.0"
 version = "1.0.14"
 
 [dependencies.impl-tools-lib]
-version = "0.7.1"
+version = "0.8.0"
 path = "lib"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Impl-tools
 [![Test Status](https://github.com/kas-gui/impl-tools/workflows/Tests/badge.svg?event=push)](https://github.com/kas-gui/impl-tools/actions)
 [![Latest version](https://img.shields.io/crates/v/impl-tools.svg)](https://crates.io/crates/impl-tools)
 [![API](https://docs.rs/impl-tools/badge.svg)](https://docs.rs/impl-tools)
-[![Minimum rustc version](https://img.shields.io/badge/rustc-1.56+-lightgray.svg)](https://github.com/kas-gui/impl-tools#supported-rust-versions)
+[![Minimum rustc version](https://img.shields.io/badge/rustc-1.58+-lightgray.svg)](https://github.com/kas-gui/impl-tools#supported-rust-versions)
 
 A set of helper macros
 
@@ -204,7 +204,7 @@ For an example of this approach, see [kas-macros](https://github.com/kas-gui/kas
 Supported Rust Versions
 ------------------------------
 
-The MSRV is 1.56.0 for no particular reason other than that it is the first to support Edition 2021.
+The MSRV is 1.58.0.
 
 When using a sufficiently recent compiler version (presumably 1.65.0), generic associated types
 are supported (only applicable to `#[autoimpl]` on trait definitions using GATs).

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "impl-tools-lib"
-version = "0.7.1"
+version = "0.8.0"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2021"
 license = "MIT/Apache-2.0"

--- a/lib/src/autoimpl.rs
+++ b/lib/src/autoimpl.rs
@@ -13,7 +13,8 @@ use quote::{quote, TokenStreamExt};
 use syn::spanned::Spanned;
 use syn::token::Comma;
 use syn::{
-    parse2, Field, Fields, Ident, Index, Item, ItemStruct, Member, Path, PathArguments, Token,
+    parse2, Field, Fields, Ident, Index, Item, ItemEnum, ItemStruct, Member, Path, PathArguments,
+    Token,
 };
 
 mod impl_misc;
@@ -74,6 +75,28 @@ pub trait ImplTrait {
         false
     }
 
+    /// Generate an impl for an enum item
+    ///
+    /// The default implementation is a wrapper around [`Self::enum_items`]
+    /// and suffices for most cases. It may be overridden, e.g. to generate
+    /// multiple implementation items. It is not recommended to modify the
+    /// generics.
+    fn enum_impl(&self, item: &ItemEnum, args: &ImplArgs) -> Result<Toks> {
+        let type_ident = &item.ident;
+        let (impl_generics, ty_generics, item_wc) = item.generics.split_for_impl();
+
+        let (path, items) = self.enum_items(item, args)?;
+
+        let wc = clause_to_toks(&args.clause, item_wc, &path);
+
+        Ok(quote! {
+            #[automatically_derived]
+            impl #impl_generics #path for #type_ident #ty_generics #wc {
+                #items
+            }
+        })
+    }
+
     /// Generate an impl for a struct item
     ///
     /// The default implementation is a wrapper around [`Self::struct_items`]
@@ -94,6 +117,24 @@ pub trait ImplTrait {
                 #items
             }
         })
+    }
+
+    /// Generate enum items
+    ///
+    /// On success, this method returns the tuple `(trait_path, items)`. These
+    /// are used to generate the following implementation:
+    /// ```ignore
+    /// impl #impl_generics #trait_path for #type_ident #ty_generics #where_clause {
+    ///     #items
+    /// }
+    /// ```
+    ///
+    /// Note: this method is *only* called by the default implementation of [`Self::enum_impl`].
+    ///
+    /// Default implementation: returns an error indicating that enum expansion is not supported.
+    fn enum_items(&self, item: &ItemEnum, args: &ImplArgs) -> Result<(Toks, Toks)> {
+        let _ = (item, args);
+        Err(Error::CallSite("enum expansion not supported"))
     }
 
     /// Generate struct items
@@ -142,6 +183,20 @@ pub enum Error {
     WithSpan(Span, &'static str),
     /// Emit an error regarding path arguments
     PathArguments(&'static str),
+}
+
+impl Error {
+    /// Report via [`proc_macro_error::emit_error`].
+    pub fn emit(self, target: Span, path_args: Span) {
+        match self {
+            Error::RequireUsing => {
+                emit_error!(target, "target requires argument `using self.FIELD`")
+            }
+            Error::CallSite(msg) => emit_error!(target, msg),
+            Error::WithSpan(span, msg) => emit_error!(span, msg),
+            Error::PathArguments(msg) => emit_error!(path_args, msg),
+        }
+    }
 }
 
 /// Result type
@@ -235,9 +290,26 @@ impl ImplTraits {
     ///
     /// This attribute does not modify the item.
     /// The caller should append the result to `item` tokens.
+    ///
+    /// Errors are reported via [`proc_macro_error::emit_error`].
     pub fn expand(
         self,
         item: Toks,
+        find_impl: impl Fn(&Path) -> Option<&'static dyn ImplTrait>,
+    ) -> Toks {
+        let mut toks = Toks::new();
+        match parse2::<Item>(item) {
+            Ok(Item::Enum(item)) => toks = self.expand_enum(item, find_impl),
+            Ok(Item::Struct(item)) => toks = self.expand_struct(item, find_impl),
+            Ok(item) => emit_error!(item, "expected struct"),
+            Err(err) => emit_error!(err),
+        }
+        toks
+    }
+
+    fn expand_enum(
+        self,
+        item: ItemEnum,
         find_impl: impl Fn(&Path) -> Option<&'static dyn ImplTrait>,
     ) -> Toks {
         let ImplTraits {
@@ -245,17 +317,66 @@ impl ImplTraits {
             mut args,
         } = self;
 
-        let item = match parse2::<Item>(item) {
-            Ok(Item::Struct(item)) => item,
-            Ok(item) => {
-                emit_error!(item, "expected struct");
-                return Toks::new();
+        if !args.ignores.is_empty() {
+            let ignores = args.ignores.iter();
+            let list = quote! { #(#ignores)* };
+            emit_error!(list, "enum expansion does not currently support `ignore`",);
+            return Toks::new();
+        }
+        if let Some(mem) = args.using {
+            emit_error!(mem, "enum expansion does not currently support `using`",);
+            return Toks::new();
+        }
+
+        let mut impl_targets: Vec<(Span, _, _)> = Vec::with_capacity(targets.len());
+        for mut target in targets.drain(..) {
+            let target_span = target.span();
+            let path_args = target
+                .segments
+                .last_mut()
+                .map(|seg| std::mem::take(&mut seg.arguments))
+                .unwrap_or(PathArguments::None);
+            let target_impl = match find_impl(&target) {
+                Some(impl_) => impl_,
+                None => {
+                    emit_error!(target, "unsupported trait");
+                    return Toks::new();
+                }
+            };
+
+            if !(path_args.is_empty() || target_impl.support_path_arguments()) {
+                emit_error!(
+                    target_span,
+                    "target {} does not support path arguments",
+                    target_impl.path()
+                );
             }
-            Err(err) => {
-                emit_error!(err);
-                return Toks::new();
+
+            impl_targets.push((target.span(), target_impl, path_args));
+        }
+
+        let mut toks = Toks::new();
+
+        for (span, target, path_args) in impl_targets.drain(..) {
+            let path_args_span = path_args.span();
+            args.path_arguments = path_args;
+            match target.enum_impl(&item, &args) {
+                Ok(items) => toks.append_all(items),
+                Err(error) => error.emit(span, path_args_span),
             }
-        };
+        }
+        toks
+    }
+
+    fn expand_struct(
+        self,
+        item: ItemStruct,
+        find_impl: impl Fn(&Path) -> Option<&'static dyn ImplTrait>,
+    ) -> Toks {
+        let ImplTraits {
+            mut targets,
+            mut args,
+        } = self;
 
         let mut not_supporting_ignore = vec![];
         let mut not_supporting_using = vec![];
@@ -347,14 +468,7 @@ impl ImplTraits {
             args.path_arguments = path_args;
             match target.struct_impl(&item, &args) {
                 Ok(items) => toks.append_all(items),
-                Err(error) => match error {
-                    Error::RequireUsing => {
-                        emit_error!(span, "target requires argument `using self.FIELD`")
-                    }
-                    Error::CallSite(msg) => emit_error!(span, msg),
-                    Error::WithSpan(span, msg) => emit_error!(span, msg),
-                    Error::PathArguments(msg) => emit_error!(path_args_span, msg),
-                },
+                Err(error) => error.emit(span, path_args_span),
             }
         }
         toks

--- a/lib/src/autoimpl/impl_misc.rs
+++ b/lib/src/autoimpl/impl_misc.rs
@@ -6,10 +6,10 @@
 //! Miscellaneous impls
 
 use super::{ImplArgs, ImplTrait, Result};
-use crate::SimplePath;
-use proc_macro2::{Span, TokenStream as Toks};
+use crate::{IdentFormatter, SimplePath};
+use proc_macro2::TokenStream as Toks;
 use quote::{quote, ToTokens, TokenStreamExt};
-use syn::{Fields, Ident, Index, ItemEnum, ItemStruct, Member, Token};
+use syn::{Fields, Index, ItemEnum, ItemStruct, Member, Token};
 
 /// Implement [`core::clone::Clone`]
 pub struct ImplClone;
@@ -23,6 +23,7 @@ impl ImplTrait for ImplClone {
     }
 
     fn enum_items(&self, item: &ItemEnum, _: &ImplArgs) -> Result<(Toks, Toks)> {
+        let mut idfmt = IdentFormatter::new();
         let name = &item.ident;
         let mut variants = Toks::new();
         for v in item.variants.iter() {
@@ -42,7 +43,7 @@ impl ImplTrait for ImplClone {
                     let mut bindings = Vec::with_capacity(len);
                     let mut items = Vec::with_capacity(len);
                     for i in 0..len {
-                        let ident = Ident::new(&format!("_{}", i), Span::call_site());
+                        let ident = idfmt.make_call_site(format_args!("_{i}"));
                         bindings.push(quote! { ref #ident });
                         items.push(quote! { #ident.clone() });
                     }
@@ -131,6 +132,7 @@ impl ImplTrait for ImplDebug {
     }
 
     fn enum_items(&self, item: &ItemEnum, _: &ImplArgs) -> Result<(Toks, Toks)> {
+        let mut idfmt = IdentFormatter::new();
         let name = &item.ident;
         let type_name = item.ident.to_string();
         let mut variants = Toks::new();
@@ -156,7 +158,7 @@ impl ImplTrait for ImplDebug {
                     let mut bindings = Vec::with_capacity(len);
                     let mut items = Toks::new();
                     for i in 0..len {
-                        let ident = Ident::new(&format!("_{}", i), Span::call_site());
+                        let ident = idfmt.make_call_site(format_args!("_{i}"));
                         bindings.push(quote! { ref #ident });
                         items.append_all(quote! { .field(#ident) });
                     }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -24,8 +24,43 @@ mod singleton;
 
 pub use default::{find_attr_impl_default, AttrImplDefault, ImplDefault};
 pub use for_deref::ForDeref;
+use proc_macro2::Span;
 pub use scope::{Scope, ScopeAttr, ScopeItem};
 pub use singleton::{Singleton, SingletonField, SingletonScope};
+use syn::Ident;
+
+/// Tool to make a formatted [`Ident`]
+pub struct IdentFormatter(String);
+impl IdentFormatter {
+    /// Construct a formatter
+    pub fn new() -> Self {
+        IdentFormatter(String::with_capacity(32))
+    }
+
+    /// Construct a new [`Ident`]
+    pub fn make(&mut self, args: std::fmt::Arguments, span: Span) -> Ident {
+        use std::fmt::Write;
+
+        self.0.clear();
+        self.0.write_fmt(args).unwrap();
+        Ident::new(&self.0, span)
+    }
+
+    /// Construct a new [`Ident`], using [`Span::call_site`]
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use impl_tools_lib::IdentFormatter;
+    /// let mut idfmt = IdentFormatter::new();
+    /// let ident = idfmt.make_call_site(format_args!("x{}", 6));
+    /// assert_eq!(ident, "x6");
+    /// ```
+    #[inline]
+    pub fn make_call_site(&mut self, args: std::fmt::Arguments) -> Ident {
+        self.make(args, Span::call_site())
+    }
+}
 
 /// Simple, allocation-free path representation
 #[derive(PartialEq, Eq)]

--- a/tests/autoimpl.rs
+++ b/tests/autoimpl.rs
@@ -42,6 +42,13 @@ struct X<A, B: Debug, C> {
     c: PhantomData<C>,
 }
 
+#[autoimpl(Clone where A: trait, B: trait)]
+#[autoimpl(Debug where A: Debug)]
+enum MaybeX<A, B: Debug, C> {
+    None,
+    Some(X<A, B, C>),
+}
+
 #[test]
 fn x() {
     let x = X {
@@ -52,7 +59,11 @@ fn x() {
     let y = x.clone();
     assert_eq!(x.a, y.a);
     assert_eq!(x.b, y.b);
-    assert_eq!(format!("{:?}", x), "X { a: 1, b: \"abc\", .. }");
+    assert_eq!(format!("{x:?}"), "X { a: 1, b: \"abc\", .. }");
+
+    let none = MaybeX::<(), (), ()>::None;
+    assert_eq!(format!("{none:?}"), "MaybeX::None");
+    test_has_clone(MaybeX::Some(x));
 }
 
 #[autoimpl(Deref, DerefMut using self.t)]

--- a/tests/autoimpl_enum.rs
+++ b/tests/autoimpl_enum.rs
@@ -5,7 +5,7 @@
 extern crate alloc;
 use alloc::format;
 
-use impl_tools::autoimpl;
+use impl_tools::{autoimpl, impl_default};
 
 fn test_has_clone(_: impl Clone) {}
 fn test_has_copy(_: impl Copy) {}
@@ -42,6 +42,7 @@ fn variants() {
 }
 
 #[autoimpl(Copy, Clone, Debug where T: trait)]
+#[impl_default(MyOption::None)]
 enum MyOption<T> {
     None,
     Some(T),
@@ -49,7 +50,7 @@ enum MyOption<T> {
 
 #[test]
 fn my_option() {
-    test_has_clone(MyOption::<i32>::None);
+    test_has_clone(MyOption::<i32>::default());
     test_has_copy(MyOption::Some(1));
     assert_eq!(format!("{:?}", MyOption::Some(1)), "MyOption::Some(1)");
 }

--- a/tests/autoimpl_enum.rs
+++ b/tests/autoimpl_enum.rs
@@ -1,0 +1,55 @@
+//! Test #[autoimpl] for trait implementations
+
+// Test no_std
+#![no_std]
+extern crate alloc;
+use alloc::format;
+
+use impl_tools::autoimpl;
+
+fn test_has_clone(_: impl Clone) {}
+fn test_has_copy(_: impl Copy) {}
+
+#[autoimpl(std::clone::Clone, core::fmt::Debug)]
+enum Void {}
+
+#[autoimpl(std::marker::Copy, std::clone::Clone, core::fmt::Debug)]
+enum Variants {
+    A,
+    B(()),
+    C(&'static str, i32),
+    #[allow(unused)]
+    D {
+        x: i32,
+        y: i32,
+    },
+}
+
+#[test]
+fn variants() {
+    test_has_copy(Variants::A);
+    test_has_clone(Variants::A);
+    assert_eq!(format!("{:?}", Variants::A), "Variants::A");
+    assert_eq!(format!("{:?}", Variants::B(())), "Variants::B(())");
+    assert_eq!(
+        format!("{:?}", Variants::C("abc", 3)),
+        "Variants::C(\"abc\", 3)"
+    );
+    assert_eq!(
+        format!("{:?}", Variants::D { x: 3, y: 2 }),
+        "Variants::D { x: 3, y: 2 }"
+    );
+}
+
+#[autoimpl(Copy, Clone, Debug where T: trait)]
+enum MyOption<T> {
+    None,
+    Some(T),
+}
+
+#[test]
+fn my_option() {
+    test_has_clone(MyOption::<i32>::None);
+    test_has_copy(MyOption::Some(1));
+    assert_eq!(format!("{:?}", MyOption::Some(1)), "MyOption::Some(1)");
+}

--- a/tests/autoimpl_enum.rs
+++ b/tests/autoimpl_enum.rs
@@ -11,9 +11,11 @@ fn test_has_clone(_: impl Clone) {}
 fn test_has_copy(_: impl Copy) {}
 
 #[autoimpl(std::clone::Clone, core::fmt::Debug)]
+#[autoimpl(std::cmp::PartialEq, std::cmp::Eq)]
 enum Void {}
 
 #[autoimpl(std::marker::Copy, std::clone::Clone, core::fmt::Debug)]
+#[autoimpl(PartialEq, Eq)]
 enum Variants {
     A,
     B(()),
@@ -43,6 +45,7 @@ fn variants() {
 
 #[autoimpl(Copy, Clone, Debug where T: trait)]
 #[impl_default(MyOption::None)]
+#[autoimpl(PartialEq, Eq where T: trait)]
 enum MyOption<T> {
     None,
     Some(T),

--- a/tests/autoimpl_enum.rs
+++ b/tests/autoimpl_enum.rs
@@ -11,11 +11,11 @@ fn test_has_clone(_: impl Clone) {}
 fn test_has_copy(_: impl Copy) {}
 
 #[autoimpl(std::clone::Clone, core::fmt::Debug)]
-#[autoimpl(std::cmp::PartialEq, std::cmp::Eq)]
+#[autoimpl(std::cmp::PartialEq, std::cmp::Eq, core::hash::Hash)]
 enum Void {}
 
 #[autoimpl(std::marker::Copy, std::clone::Clone, core::fmt::Debug)]
-#[autoimpl(PartialEq, Eq)]
+#[autoimpl(PartialEq, Eq, Hash)]
 enum Variants {
     A,
     B(()),


### PR DESCRIPTION
Add support for `#[autoimpl(..)]` on enums. Closes #6.

From the point of view of the implementing traits, this is opt-in. The following traits are currently supported: Clone, Copy, Debug, PartialEq, Eq. Not currently supported (because I'm lazy): PartialOrd, Ord.

Autoimpl for enums supports a `where` clause, but does not support `using` or `ignore` clauses. Mostly, this is because of syntactic ambiguity (see #6).

@ycscaly could you please test this?