### PR TITLE
0.9.0: update to syn v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.8.0] — 2022-02-07
+## [0.9.0] — 2023-06-28
+
+-   Update to syn v2.0.0
+
+## [0.8.0] — 2023-02-07
 
 -   Bump MSRV to 1.58.0 (#31)
 -   `#[autoimpl(Clone, Debug, PartialEq, Eq, Hash)]` now all support enums

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "impl-tools"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2021"
 license = "MIT/Apache-2.0"
@@ -21,7 +21,7 @@ proc-macro-error = "1.0"
 version = "2.0.0"
 
 [dependencies.impl-tools-lib]
-version = "0.8.0"
+version = "0.9.0"
 path = "lib"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ proc-macro = true
 proc-macro-error = "1.0"
 
 [dependencies.syn]
-version = "1.0.14"
+version = "2.0.0"
 
 [dependencies.impl-tools-lib]
 version = "0.8.0"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -16,7 +16,7 @@ proc-macro2 = { version = "1.0" }
 proc-macro-error = "1.0"
 
 [dependencies.syn]
-version = "1.0.14"
+version = "2.0.0"
 # We need 'extra-traits' for equality testing
 # We need 'full' for parsing macros within macro arguments
 features = ["extra-traits", "full", "visit", "visit-mut"]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "impl-tools-lib"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2021"
 license = "MIT/Apache-2.0"

--- a/lib/src/autoimpl.rs
+++ b/lib/src/autoimpl.rs
@@ -297,14 +297,15 @@ impl ImplTraits {
         item: Toks,
         find_impl: impl Fn(&Path) -> Option<&'static dyn ImplTrait>,
     ) -> Toks {
-        let mut toks = Toks::new();
         match parse2::<Item>(item) {
-            Ok(Item::Enum(item)) => toks = self.expand_enum(item, find_impl),
-            Ok(Item::Struct(item)) => toks = self.expand_struct(item, find_impl),
-            Ok(item) => emit_error!(item, "expected struct"),
-            Err(err) => emit_error!(err),
+            Ok(Item::Enum(item)) => self.expand_enum(item, find_impl),
+            Ok(Item::Struct(item)) => self.expand_struct(item, find_impl),
+            Ok(item) => {
+                emit_error!(item, "expected struct");
+                Toks::new()
+            }
+            Err(err) => err.into_compile_error(),
         }
-        toks
     }
 
     fn expand_enum(

--- a/lib/src/autoimpl/impl_using.rs
+++ b/lib/src/autoimpl/impl_using.rs
@@ -144,7 +144,7 @@ impl ImplTrait for ImplDeref {
                 }) => {
                     let mut result = None;
                     for arg in args {
-                        if let syn::GenericArgument::Binding(b) = arg {
+                        if let syn::GenericArgument::AssocType(b) = arg {
                             if b.ident == "Target" && result.is_none() {
                                 result = Some(b.ty.clone());
                                 continue;

--- a/lib/src/default.rs
+++ b/lib/src/default.rs
@@ -11,7 +11,7 @@ use proc_macro_error::emit_error;
 use quote::quote;
 use syn::parse::{Error, Parse, ParseStream, Result};
 use syn::spanned::Spanned;
-use syn::{parse2, Attribute, Expr, Generics, Ident, Item, Token};
+use syn::{parse2, Attribute, Expr, Generics, Ident, Item, Meta, Token};
 
 /// `#[impl_default]` attribute
 pub struct ImplDefault {
@@ -83,14 +83,18 @@ impl ImplDefault {
     }
 
     fn parse_attr(attr: Attribute) -> Result<Self> {
-        if attr.tokens.is_empty() {
-            return Ok(ImplDefault {
+        match attr.meta {
+            Meta::Path(_) => Ok(ImplDefault {
                 expr: None,
                 where_clause: None,
                 span: attr.span(),
-            });
+            }),
+            Meta::List(list) => list.parse_args(),
+            Meta::NameValue(meta) => Err(Error::new_spanned(
+                meta,
+                "expected #[impl_default] or #[impl_default(EXPR)]",
+            )),
         }
-        attr.parse_args()
     }
 }
 

--- a/lib/src/fields.rs
+++ b/lib/src/fields.rs
@@ -93,7 +93,7 @@ pub(crate) mod parsing {
             let brace_token = braced!(content in input);
             Ok(FieldsNamed {
                 brace_token,
-                fields: content.parse_terminated(Field::parse_named)?,
+                fields: content.parse_terminated(Field::parse_named, Token![,])?,
             })
         }
     }
@@ -104,7 +104,7 @@ pub(crate) mod parsing {
             let paren_token = parenthesized!(content in input);
             Ok(FieldsUnnamed {
                 paren_token,
-                fields: content.parse_terminated(Field::parse_unnamed)?,
+                fields: content.parse_terminated(Field::parse_unnamed, Token![,])?,
             })
         }
     }
@@ -186,7 +186,7 @@ pub(crate) mod parsing {
     fn parse_braced(input: ParseStream) -> Result<FieldsNamed> {
         let content;
         let brace_token = braced!(content in input);
-        let fields = content.parse_terminated(Field::parse_named)?;
+        let fields = content.parse_terminated(Field::parse_named, Token![,])?;
         Ok(FieldsNamed {
             brace_token,
             fields,

--- a/lib/src/for_deref.rs
+++ b/lib/src/for_deref.rs
@@ -12,7 +12,7 @@ use quote::{quote, ToTokens, TokenStreamExt};
 use std::{iter, slice};
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
-use syn::token::{Colon2, Comma, Eq};
+use syn::token::{Comma, Eq, PathSep};
 use syn::{parse_quote, Attribute, FnArg, Ident, Item, Token, TraitItem, Type, TypePath};
 
 /// Autoimpl for types supporting `Deref`
@@ -151,10 +151,7 @@ impl ForDeref {
                 emit_error!(item, "expected trait");
                 return TokenStream::new();
             }
-            Err(err) => {
-                emit_error!(err);
-                return TokenStream::new();
-            }
+            Err(err) => return err.into_compile_error(),
         };
 
         #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -182,7 +179,7 @@ impl ForDeref {
             match item {
                 TraitItem::Const(item) => {
                     for attr in item.attrs.iter() {
-                        if attr.path == parse_quote! { cfg } {
+                        if *attr.path() == parse_quote! { cfg } {
                             attr.to_tokens(tokens);
                         }
                     }
@@ -194,14 +191,14 @@ impl ForDeref {
 
                     Eq::default().to_tokens(tokens);
                     definitive.to_tokens(tokens);
-                    Colon2::default().to_tokens(tokens);
+                    PathSep::default().to_tokens(tokens);
                     item.ident.to_tokens(tokens);
 
                     item.semi_token.to_tokens(tokens);
                 }
-                TraitItem::Method(item) => {
+                TraitItem::Fn(item) => {
                     for attr in item.attrs.iter() {
-                        if attr.path == parse_quote! { cfg } {
+                        if *attr.path() == parse_quote! { cfg } {
                             attr.to_tokens(tokens);
                         }
                     }
@@ -255,7 +252,7 @@ impl ForDeref {
                 }
                 TraitItem::Type(item) => {
                     for attr in item.attrs.iter() {
-                        if attr.path == parse_quote! { cfg } {
+                        if *attr.path() == parse_quote! { cfg } {
                             attr.to_tokens(tokens);
                         }
                     }
@@ -275,7 +272,7 @@ impl ForDeref {
 
                     Eq::default().to_tokens(tokens);
                     definitive.to_tokens(tokens);
-                    Colon2::default().to_tokens(tokens);
+                    PathSep::default().to_tokens(tokens);
                     item.ident.to_tokens(tokens);
                     ty_generics.to_tokens(tokens);
 

--- a/lib/src/generics.rs
+++ b/lib/src/generics.rs
@@ -10,7 +10,7 @@ use quote::{quote, ToTokens, TokenStreamExt};
 use syn::parse::{Parse, ParseStream, Result};
 use syn::punctuated::{Pair, Punctuated};
 use syn::token;
-use syn::{Attribute, ConstParam, LifetimeDef, PredicateLifetime};
+use syn::{Attribute, ConstParam, LifetimeParam, PredicateLifetime};
 use syn::{BoundLifetimes, Ident, Lifetime, Token, Type};
 
 /// Lifetimes and type parameters attached an item
@@ -50,7 +50,7 @@ pub enum GenericParam {
     /// Type parameter
     Type(TypeParam),
     /// Lifetime parameter
-    Lifetime(LifetimeDef),
+    Lifetime(LifetimeParam),
     /// `const` parameter
     Const(ConstParam),
 }
@@ -149,7 +149,7 @@ mod parsing {
                 let attrs = input.call(Attribute::parse_outer)?;
                 let lookahead = input.lookahead1();
                 if lookahead.peek(Lifetime) {
-                    params.push_value(GenericParam::Lifetime(LifetimeDef {
+                    params.push_value(GenericParam::Lifetime(LifetimeParam {
                         attrs,
                         ..input.parse()?
                     }));

--- a/lib/src/scope.rs
+++ b/lib/src/scope.rs
@@ -154,7 +154,7 @@ impl Scope {
 
         let mut i = 0;
         while i < self.attrs.len() {
-            if let Some(rule) = find_rule(&self.attrs[i].path) {
+            if let Some(rule) = find_rule(&self.attrs[i].path()) {
                 let attr = self.attrs.remove(i);
 
                 if !rule.support_repetition() {
@@ -398,7 +398,7 @@ mod parsing {
 
         let content;
         let brace = braced!(content in input);
-        let variants = content.parse_terminated(Variant::parse)?;
+        let variants = content.parse_terminated(Variant::parse, Token![,])?;
 
         Ok((where_clause, brace, variants))
     }
@@ -412,7 +412,7 @@ mod parsing {
     pub(crate) fn parse_braced(input: ParseStream) -> Result<FieldsNamed> {
         let content;
         let brace_token = braced!(content in input);
-        let named = content.parse_terminated(Field::parse_named)?;
+        let named = content.parse_terminated(Field::parse_named, Token![,])?;
         Ok(FieldsNamed { brace_token, named })
     }
 }

--- a/lib/src/scope.rs
+++ b/lib/src/scope.rs
@@ -215,7 +215,7 @@ mod parsing {
     use crate::fields::parsing::data_struct;
     use syn::parse::{Parse, ParseStream};
     use syn::spanned::Spanned;
-    use syn::{braced, bracketed, AttrStyle, Error, Field, Lifetime, Path, TypePath, WhereClause};
+    use syn::{braced, Error, Field, Lifetime, Path, TypePath, WhereClause};
 
     impl Parse for Scope {
         fn parse(input: ParseStream) -> Result<Self> {
@@ -371,7 +371,7 @@ mod parsing {
 
         let content;
         let brace_token = braced!(content in input);
-        parse_attrs_inner(&content, &mut attrs)?;
+        attrs.extend(Attribute::parse_inner(&content)?);
 
         let mut items = Vec::new();
         while !content.is_empty() {
@@ -414,25 +414,6 @@ mod parsing {
         let brace_token = braced!(content in input);
         let named = content.parse_terminated(Field::parse_named)?;
         Ok(FieldsNamed { brace_token, named })
-    }
-
-    fn parse_attrs_inner(input: ParseStream, attrs: &mut Vec<Attribute>) -> Result<()> {
-        while input.peek(Token![#]) && input.peek2(Token![!]) {
-            let pound_token = input.parse()?;
-            let style = AttrStyle::Inner(input.parse()?);
-            let content;
-            let bracket_token = bracketed!(content in input);
-            let path = content.call(Path::parse_mod_style)?;
-            let tokens = content.parse()?;
-            attrs.push(Attribute {
-                pound_token,
-                style,
-                bracket_token,
-                path,
-                tokens,
-            });
-        }
-        Ok(())
     }
 }
 

--- a/lib/src/singleton.rs
+++ b/lib/src/singleton.rs
@@ -290,26 +290,7 @@ mod parsing {
     use super::*;
     use proc_macro_error::abort;
     use syn::parse::{Error, Parse, ParseStream, Result};
-    use syn::{braced, bracketed, parenthesized};
-
-    fn parse_attrs_inner(input: ParseStream, attrs: &mut Vec<Attribute>) -> Result<()> {
-        while input.peek(Token![#]) && input.peek2(Token![!]) {
-            let pound_token = input.parse()?;
-            let style = syn::AttrStyle::Inner(input.parse()?);
-            let content;
-            let bracket_token = bracketed!(content in input);
-            let path = content.call(syn::Path::parse_mod_style)?;
-            let tokens = content.parse()?;
-            attrs.push(Attribute {
-                pound_token,
-                style,
-                bracket_token,
-                path,
-                tokens,
-            });
-        }
-        Ok(())
-    }
+    use syn::{braced, parenthesized};
 
     fn parse_impl(in_ident: Option<&Ident>, input: ParseStream) -> Result<ItemImpl> {
         let mut attrs = input.call(Attribute::parse_outer)?;
@@ -388,7 +369,7 @@ mod parsing {
 
         let content;
         let brace_token = braced!(content in input);
-        parse_attrs_inner(&content, &mut attrs)?;
+        attrs.extend(Attribute::parse_inner(&content)?);
 
         let mut items = Vec::new();
         while !content.is_empty() {

--- a/lib/src/singleton.rs
+++ b/lib/src/singleton.rs
@@ -500,7 +500,7 @@ mod parsing {
             if generics.where_clause.is_none() && lookahead.peek(Paren) {
                 let content;
                 let paren_token = parenthesized!(content in input);
-                fields = content.parse_terminated(SingletonField::parse_unnamed)?;
+                fields = content.parse_terminated(SingletonField::parse_unnamed, Token![,])?;
 
                 lookahead = input.lookahead1();
                 if lookahead.peek(Token![where]) {
@@ -517,7 +517,7 @@ mod parsing {
                 let content;
                 let brace_token = braced!(content in input);
                 style = StructStyle::Regular(brace_token);
-                fields = content.parse_terminated(SingletonField::parse_named)?;
+                fields = content.parse_terminated(SingletonField::parse_named, Token![,])?;
             } else if lookahead.peek(Semi) {
                 style = StructStyle::Unit(input.parse()?);
                 fields = Punctuated::new();


### PR DESCRIPTION
The update is breaking for `impl-tools-lib` but not for `impl-tools`; however, as a proc-macro crate, there is very little reason to care about making a new breaking release so lets keep the numbers in sync (unlike v0.7).