### PR TITLE
Disable the syn v1 dependency of proc-macro-error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,9 @@ documentation = "https://docs.rs/impl-tools/"
 [lib]
 proc-macro = true
 
-[dependencies]
-proc-macro-error = "1.0"
+[dependencies.proc-macro-error]
+version = "1.0"
+default-features = false
 
 [dependencies.syn]
 version = "2.0.0"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -12,8 +12,11 @@ documentation = "https://docs.rs/impl-tools-lib/"
 
 [dependencies]
 quote = "1.0"
-proc-macro2 = { version = "1.0" }
-proc-macro-error = "1.0"
+proc-macro2 = "1.0"
+
+[dependencies.proc-macro-error]
+version = "1.0"
+default-features = false
 
 [dependencies.syn]
 version = "2.0.0"


### PR DESCRIPTION
This is only needed for `impl From<syn::Error> for Diagnostic`, which is
irrelevant when impl-tools is using syn v2.
