### PR TITLE
Support non-ident patterns in fn args

### DIFF
--- a/tests/for_deref.rs
+++ b/tests/for_deref.rs
@@ -40,6 +40,13 @@ fn z() {
     impls_z(Box::new(()));
 }
 
+#[autoimpl(for<'a, T> &'a mut T where T: trait + ?Sized)]
+pub trait BitRead2 {
+    fn copy_to(&mut self, mut _n: u64) -> Result<(), core::convert::Infallible> {
+        Ok(())
+    }
+}
+
 #[autoimpl(for<'a, T> &'a T, &'a mut T, Box<T> where T: trait + ?Sized)]
 trait G<V>
 where

--- a/tests/for_deref.rs
+++ b/tests/for_deref.rs
@@ -45,6 +45,9 @@ pub trait BitRead2 {
     fn copy_to(&mut self, mut _n: u64) -> Result<(), core::convert::Infallible> {
         Ok(())
     }
+
+    #[allow(unused_parens)]
+    fn fn_with_parens(&self, (_x): i32) {}
 }
 
 #[autoimpl(for<'a, T> &'a T, &'a mut T, Box<T> where T: trait + ?Sized)]

--- a/tests/for_deref.rs
+++ b/tests/for_deref.rs
@@ -40,14 +40,24 @@ fn z() {
     impls_z(Box::new(()));
 }
 
+macro_rules! ident {
+    ($t:tt) => {
+        $t
+    };
+}
+
 #[autoimpl(for<'a, T> &'a mut T where T: trait + ?Sized)]
 pub trait BitRead2 {
     fn copy_to(&mut self, mut _n: u64) -> Result<(), core::convert::Infallible> {
         Ok(())
     }
 
+    fn p(&self, ident!(_x): i32);
+
     #[allow(unused_parens)]
     fn fn_with_parens(&self, (_x): i32) {}
+
+    fn fn_with_path(&self, core::any::TypeId { .. }: core::any::TypeId) {}
 }
 
 #[autoimpl(for<'a, T> &'a T, &'a mut T, Box<T> where T: trait + ?Sized)]


### PR DESCRIPTION
This fixes the bug reported in #44, but not the doc issue.