### PR TITLE
Improve docs for #[autoimpl]

### DIFF
--- a/lib/src/autoimpl.rs
+++ b/lib/src/autoimpl.rs
@@ -188,7 +188,7 @@ pub enum Error {
 }
 
 impl Error {
-    /// Report via [`proc_macro_error::emit_error`].
+    /// Report via [`proc_macro_error2::emit_error`].
     pub fn emit(self, target: Span, path_args: Span) {
         match self {
             Error::RequireUsing => {
@@ -293,7 +293,7 @@ impl ImplTraits {
     /// This attribute does not modify the item.
     /// The caller should append the result to `item` tokens.
     ///
-    /// Errors are reported via [`proc_macro_error::emit_error`].
+    /// Errors are reported via [`proc_macro_error2::emit_error`].
     pub fn expand(
         self,
         item: Toks,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,29 +9,31 @@
 
 //! # Impl-tools
 //!
-//! `#[autoimpl]` is a partial replacement for `#[derive]`, supporting:
+//! [`#[autoimpl]`](macro@autoimpl) is a partial replacement for
+//! [`#[derive]`](https://doc.rust-lang.org/stable/reference/attributes/derive.html),
+//! supporting:
 //!
 //! -   Explicit `where` clause on generic parameters
 //! -   No implicit bounds on generic parameters beyond those required by the type
 //! -   Traits like `Deref` by `using` a named field
 //! -   Traits like `Debug` may `ignore` named fields
 //!
-//! `#[autoimpl]` may also be used on trait definitions to *re-implement* the
+//! [`#[autoimpl]`](macro@autoimpl) may also be used on trait definitions to *re-implement* the
 //! trait for given reference types.
 //!
-//! `impl_scope!` is a function-like macro used to define a type plus its
+//! [`impl_scope!`] is a function-like macro used to define a type plus its
 //! implementations. It supports two things:
 //!
 //! -   `impl Self` syntax
 //! -   Evaluation of advanced attribute macros, which may use field
 //!     initializers and read/write other impls within the scope
 //!
-//! `impl_anon!` is a function-like macro used to define and instantiate a
-//! unique (single-use) type. It supports everything supported by `impl_scope!`
+//! [`impl_anon!`] is a function-like macro used to define and instantiate a
+//! unique (single-use) type. It supports everything supported by [`impl_scope!`]
 //! plus field initializers and (limited) automatic typing of fields.
 //!
-//! User-extensions to both `#[autoimpl]` and `impl_scope!` are possible, by
-//! writing your own proc-macro crate depending on
+//! User-extensions to both [`#[autoimpl]`](macro@autoimpl) and [`impl_scope!`]
+//! are possible, by writing your own proc-macro crate depending on
 //! [impl-tools-lib](https://crates.io/crates/impl-tools-lib).
 
 #[cfg(doctest)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,31 +9,25 @@
 
 //! # Impl-tools
 //!
-//! [`#[autoimpl]`](macro@autoimpl) is a partial replacement for
-//! [`#[derive]`](https://doc.rust-lang.org/stable/reference/attributes/derive.html),
-//! supporting:
+//! [`#[autoimpl]`](macro@autoimpl) is an alternative to
+//! [`#[derive]`](macro@derive) with more features (also usable on traits).
 //!
-//! -   Explicit `where` clause on generic parameters
-//! -   No implicit bounds on generic parameters beyond those required by the type
-//! -   Traits like `Deref` by `using` a named field
-//! -   Traits like `Debug` may `ignore` named fields
+//! [`#[impl_default]`](macro@impl_default) is shorthand for implementing
+//! [`Default`] with an explicit default value.
+//! It supports structs and enums.
 //!
-//! [`#[autoimpl]`](macro@autoimpl) may also be used on trait definitions to *re-implement* the
-//! trait for given reference types.
+//! [`impl_scope!`] is a function-like macro used to define a type together with
+//! its implementations. This allows:
 //!
-//! [`impl_scope!`] is a function-like macro used to define a type plus its
-//! implementations. It supports two things:
-//!
-//! -   `impl Self` syntax
-//! -   Evaluation of advanced attribute macros, which may use field
-//!     initializers and read/write other impls within the scope
+//! -   `impl Self` syntax (avoid repeated definitions of generics)
+//! -   Evaluation of some more complex attribute macros
 //!
 //! [`impl_anon!`] is a function-like macro used to define and instantiate a
 //! unique (single-use) type. It supports everything supported by [`impl_scope!`]
 //! plus field initializers and (limited) automatic typing of fields.
 //!
 //! User-extensions to both [`#[autoimpl]`](macro@autoimpl) and [`impl_scope!`]
-//! are possible, by writing your own proc-macro crate depending on
+//! are possible with a custom proc-macro crate depending on
 //! [impl-tools-lib](https://crates.io/crates/impl-tools-lib).
 
 #[cfg(doctest)]


### PR DESCRIPTION
Also shorten top-level docs for `impl-tools`.

Closes #44.