### PR TITLE
Unsized definitive ty

### DIFF
--- a/lib/src/autoimpl/for_deref.rs
+++ b/lib/src/autoimpl/for_deref.rs
@@ -132,7 +132,7 @@ fn has_bound_on_self(item: &TraitItem) -> bool {
         TraitItem::Const(ref item) => &item.generics,
         TraitItem::Fn(ref item) => &item.sig.generics,
         TraitItem::Type(ref item) => &item.generics,
-        TraitItem::Macro(_) | TraitItem::Verbatim(_) => return false,
+        _ => return false,
     };
 
     if let Some(ref clause) = gen.where_clause {

--- a/lib/src/autoimpl/for_deref.rs
+++ b/lib/src/autoimpl/for_deref.rs
@@ -216,10 +216,10 @@ impl ForDeref {
                         }
                     }
 
-                    if has_bound_on_self(&item.sig.generics) {
-                        // If the method has a bound on Self, we cannot use a dereferencing
-                        // implementation since the definitive type is not guaranteed to match
-                        // the bound (we also cannot add a bound).
+                    if !self.definitive_has_sized_bound && has_bound_on_self(&item.sig.generics) {
+                        // If the method has a bound on Self without the definitive type having a
+                        // bound on Self we cannot use a dereferencing implementation since the
+                        // definitive type is not guaranteed to match the bound.
 
                         if item.default.is_none() {
                             emit_call_site_error!(

--- a/lib/src/autoimpl/for_deref.rs
+++ b/lib/src/autoimpl/for_deref.rs
@@ -202,10 +202,9 @@ impl ForDeref {
                 // definitive type is not guaranteed to match the bound.
 
                 // if item.default.is_none() {
-                    emit_call_site_error!(
-                        "cannot autoimpl trait with Deref";
-                        note = item.span() => "item has a Self: Sized bound";
-                        note = definitive_ty.span() => "definitive type does not have a Sized bound";
+                    emit_error!(
+                        item, "cannot autoimpl this trait item with `Self: Sized` bound with Deref";
+                        note = definitive_ty.span() => "definitive type `{}` does not have a Sized bound", definitive_ty;
                     );
                 // }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,10 +238,15 @@ pub fn impl_default(args: TokenStream, item: TokenStream) -> TokenStream {
 /// Traits using generics and trait items using generics are, for the most part,
 /// supported.
 ///
-/// Items with a where clause with a type bound on `Self` are not supported
+/// Items with a `where Self: Sized` bound are only supported
+/// when the definitive type is also `Sized`.
 /// since the item is not guaranteed to exist on the definitive type.
 /// Exception: methods with a default implementation (in this case the item is
 /// skipped).
+///
+/// TODO: can we instead add a bound like `Target: Sized`?
+/// A: yes. But: now we should choose whether cases with a default impl should
+/// (a) continue to use the default impl or (b) require the `Target: Sized` bound.
 ///
 /// An example:
 /// ```

--- a/tests/for_deref.rs
+++ b/tests/for_deref.rs
@@ -82,6 +82,10 @@ fn g() {
         fn g(&self) -> i32 {
             123
         }
+
+        fn s<X>(&self, f: impl Fn(i32) -> X) -> X {
+            f(self.g())
+        }
     }
 
     fn impls_g(g: impl G<i32>) {
@@ -108,6 +112,11 @@ where
     X: Debug,
 {
 }
+
+// #[autoimpl(for<T: trait + ?Sized> &T)]
+// trait I {
+//     fn f(&self) where Self: Sized;
+// }
 
 #[cfg(rustc_1_65)]
 #[autoimpl(for<A: trait + ?Sized> Box<A>)]


### PR DESCRIPTION
Take this example:
```rust
#[autoimpl(for<'a, T> &'a T, &'a mut T, Box<T> where T: trait + Sized)]
trait G<V>
where
    V: Debug,
{
    fn g(&self) -> V;

    fn s<X>(&self, f: impl Fn(V) -> X) -> X
    where
        Self: Sized,
    {
        f(self.g())
    }
}
```

Without this PR, `autoimpl` will impl `G` over `T: G + Sized`, skipping the impl of `G::s` due to the `Self::Sized` bound. This is valid only because a default impl of `G::s` is provided.

With this PR, `autoimpl` will now provide an impl of `G::s` over `T: G + Sized`.

---

Modify the example such that `T: trait + ?Sized` and the story is different:

- Without this PR is the same as above: `autoimpl` does not implement `G::s`
- With this PR, an error is emitted since `T: G + ?Sized` does not satisfy `Self: Sized` in the impl.
- We could modify this PR to behave as before (not generate `fn G::s`) only in this case (the fn requires `Sized` but the definitive ty `T` does not), but this behaviour would be inconsistent (surprising)