### PR TITLE
Fixed bug in Clone autoimpl

### DIFF
--- a/lib/src/autoimpl/impl_misc.rs
+++ b/lib/src/autoimpl/impl_misc.rs
@@ -31,10 +31,13 @@ impl ImplTrait for ImplClone {
             let tag = quote! { #name :: #ident };
             variants.append_all(match v.fields {
                 Fields::Named(ref fields) => {
-                    let idents = fields.named.iter().map(|f| f.ident.as_ref().unwrap());
+                    let idents = fields.named.iter().map(|f| {
+                        let ident = f.ident.as_ref().unwrap();
+                        quote! { #ident:ref #ident }
+                    });
                     let clones = fields.named.iter().map(|f| {
                         let ident = f.ident.as_ref().unwrap();
-                        quote! { #ident: ::core::clone::Clone::clone(&#ident) }
+                        quote! { #ident: ::core::clone::Clone::clone(#ident) }
                     });
                     quote! { #tag { #(#idents),* } => #tag { #(#clones),* }, }
                 }

--- a/tests/autoimpl_enum.rs
+++ b/tests/autoimpl_enum.rs
@@ -28,10 +28,23 @@ enum Variants {
     },
 }
 
+#[autoimpl(std::clone::Clone)]
+#[allow(unused)]
+struct NotCopy(i32);
+
+#[autoimpl(std::clone::Clone)]
+#[allow(unused)]
+enum CloneNotCopy {
+    A { not_copy: NotCopy },
+}
+
 #[test]
 fn variants() {
     test_has_copy(Variants::A);
     test_has_clone(Variants::A);
+    test_has_clone(CloneNotCopy::A {
+        not_copy: NotCopy(0),
+    });
     assert_eq!(format!("{:?}", Variants::A), "Variants::A");
     assert_eq!(format!("{:?}", Variants::B(())), "Variants::B(())");
     assert_eq!(


### PR DESCRIPTION
Consider an enum variant with non-Copy named fields such as
```rust
#[autoimpl(Clone)]
enum Foo {
  Buggy { 
    field_a: String, 
    field_b: String
  }
}
```
...this expands to an impl such as:
```rust
match *self {
  Foo::Buggy{ field_a, field_b } => Foo::Buggy{ 
    field_a: ::core::clone::Clone::clone(&field_a),
    field_b: ::core::clone::Clone::clone(&field_b),
  }
}
```
...where `clone` correctly uses references `&field_a` and `&field_b`, but since the match is on `*self`, the match itself already takes ownership of `self` and moves `field_a` and `field_b` into the match arm. The result is that the `autoimpl` macro throws a compile error "cannot move out of a shared reference".

This PR replaces the match arm `Foo::Buggy{ field_a, field_b}` by `Foo::Buggy{ field_a:ref field_a, field_b: ref field_b}`, which avoids moving ownership (and subsequently removes the `&` in `clone`).

Thank you