### PR TITLE
Let #[autoimpl(Clone, Debug, Default)] support #[cfg] on variants and fields

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,60 +7,47 @@ on:
     branches: [ master, '[0-9]+.[0-9]+' ]
 
 jobs:
-  nightly:
-    name: Nightly, format and Doc
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-      - name: Install toolchain
-        uses: dtolnay/rust-toolchain@nightly
-      - name: Build docs
-        run: cargo doc --all-features --all --no-deps
-      - name: Test impl-tools-lib
-        run: cargo test --manifest-path lib/Cargo.toml --all-features
-      - name: Test impl-tools
-        run: cargo test --all-features
+  test:
+    name: Test
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            toolchain: nightly
+            variant: docs
+          - os: macos-latest
+            toolchain: beta
+          - os: windows-latest
+            toolchain: stable
+          - os: ubuntu-latest
+            toolchain: "1.66.0"
+            targets: "--lib --tests"
+            variant: MSRV
 
-  beta:
-    name: Beta on MacOS
-    runs-on: macos-latest
-
-    steps:
-      - uses: actions/checkout@v5
-      - name: Install toolchain
-        uses: dtolnay/rust-toolchain@beta
-      - name: Test impl-tools-lib
-        run: cargo test --manifest-path lib/Cargo.toml --all-features
-      - name: Test impl-tools
-        run: cargo test --all-features
-
-  stable:
-    name: Stable on Windows
-    runs-on: windows-latest
+    runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v5
-      - name: Install toolchain
-        uses: dtolnay/rust-toolchain@stable
-      - name: Test impl-tools-lib
-        run: cargo test --manifest-path lib/Cargo.toml --all-features
-      - name: Test impl-tools
-        run: cargo test --all-features
+      - name: Checkout
+        uses: actions/checkout@v5
 
-  msrv:
-    name: MSRV
-    runs-on: macos-latest
-
-    steps:
-      - uses: actions/checkout@v5
-      - name: Install toolchain
-        uses: dtolnay/rust-toolchain@1.66.0
-      - name: Use Cargo.lock.msrv
+      - name: MSRV
+        if: ${{ matrix.variant == 'MSRV' }}
         run: cp Cargo.lock.msrv Cargo.lock
+
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.toolchain }}
+
+      - name: Build docs
+        if: ${{ matrix.variant == 'docs' }}
+        run: cargo doc --all-features --all --no-deps
+
       - name: Test impl-tools-lib
-        run: cargo test --manifest-path lib/Cargo.toml --all-features --lib --tests
+        run: cargo test --manifest-path lib/Cargo.toml --all-features ${{ matrix.targets }}
+
       - name: Test impl-tools
-        run: cargo test --all-features --lib --tests
+        run: cargo test --all-features ${{ matrix.targets }}
 
   workspace:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,12 @@ jobs:
       - name: Test impl-tools
         run: cargo test --all-features ${{ matrix.targets }}
 
+      - name: Test test-cfg
+        working-directory: tests/test-cfg
+        run: |
+          cargo test
+          cargo test --features feature1
+
   workspace:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
           - os: windows-latest
             toolchain: stable
           - os: ubuntu-latest
-            toolchain: "1.66.0"
+            toolchain: "1.70.0"
             targets: "--lib --tests"
             variant: MSRV
 
@@ -62,7 +62,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          components: rustfmt
+          components: rustfmt,clippy
       - name: rustfmt
         run: cargo fmt --all -- --check
       - name: clippy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [0.12.0] — unreleased
+
+-   Bump MSRV to 1.70 (#59)
+-   Let `#[autoimpl(Clone, Debug, Default)]` support `#[cfg]` on struct fields, enum variants and variant fields (#59)
+-   Let `#[autoimpl(Clone, Debug)]` support `ignore` on named enum fields (#59)
+
 # [0.11.3] (lib only)
 
 -   Fix `#[autoimpl(Clone)]` and `#[autoimpl(Hash)]` for non-`Copy` enums (#55, #56)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["lib"]
+members = ["lib", "tests/test-cfg"]
 
 [workspace.package]
 authors = ["Diggory Hardy <git@dhardy.name>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["lib", "tests/test-cfg"]
 authors = ["Diggory Hardy <git@dhardy.name>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/kas-gui/impl-tools"
-rust-version = "1.65.0"
+rust-version = "1.70.0"
 edition = "2021"
 
 [package]

--- a/README.md
+++ b/README.md
@@ -203,12 +203,6 @@ For an example of this approach, see [kas-macros](https://github.com/kas-gui/kas
 [`ScopeAttr`]: https://docs.rs/impl-tools-lib/latest/impl_tools_lib/trait.ScopeAttr.html
 
 
-Supported Rust Versions
-------------------------------
-
-The MSRV is 1.65.0.
-
-
 Alternatives
 ------------
 

--- a/lib/src/autoimpl/impl_misc.rs
+++ b/lib/src/autoimpl/impl_misc.rs
@@ -169,7 +169,7 @@ impl ImplTrait for ImplDebug {
         true
     }
 
-    fn enum_items(&self, item: &ItemEnum, _: &ImplArgs) -> Result<(Toks, Toks)> {
+    fn enum_items(&self, item: &ItemEnum, args: &ImplArgs) -> Result<(Toks, Toks)> {
         let mut idfmt = IdentFormatter::new();
         let name = &item.ident;
         let type_name = item.ident.to_string();
@@ -180,28 +180,44 @@ impl ImplTrait for ImplDebug {
             let tag = quote! { #name :: #ident };
             variants.append_all(match v.fields {
                 Fields::Named(ref fields) => {
-                    let idents = fields.named.iter().map(|f| f.ident.as_ref().unwrap());
-                    let mut items = Toks::new();
+                    let mut idents = Toks::new();
+                    let mut stmts = quote! { let mut debug = f.debug_struct(#var_name); };
                     for field in fields.named.iter() {
+                        for attr in &field.attrs {
+                            if attr.path().get_ident().is_some_and(|path| path == "cfg") {
+                                attr.to_tokens(&mut idents);
+                                attr.to_tokens(&mut stmts);
+                            }
+                        }
+
                         let ident = field.ident.as_ref().unwrap();
-                        let name = ident.to_string();
-                        items.append_all(quote! { .field(#name, #ident) });
+                        idents.append_all(quote! { ref #ident, });
+                        if !args.ignore_named(ident) {
+                            let name = ident.to_string();
+                            stmts.append_all(quote! { { debug.field(#name, #ident); } });
+                        }
                     }
-                    quote! {
-                        #tag { #(ref #idents),* } => f.debug_struct(#var_name) #items .finish(),
-                    }
+                    stmts.append_all(quote! { debug.finish() });
+
+                    quote! { #tag { #idents } => { #stmts }, }
                 }
                 Fields::Unnamed(ref fields) => {
-                    let len = fields.unnamed.len();
-                    let mut bindings = Vec::with_capacity(len);
-                    let mut items = Toks::new();
-                    for i in 0..len {
+                    let mut bindings = Toks::new();
+                    let mut stmts = quote! { let mut debug = f.debug_tuple(#var_name); };
+                    for (i, field) in fields.unnamed.iter().enumerate() {
+                        for attr in &field.attrs {
+                            if attr.path().get_ident().is_some_and(|path| path == "cfg") {
+                                attr.to_tokens(&mut bindings);
+                                attr.to_tokens(&mut stmts);
+                            }
+                        }
+
                         let ident = idfmt.make_call_site(format_args!("_{i}"));
-                        bindings.push(quote! { ref #ident });
-                        items.append_all(quote! { .field(#ident) });
+                        bindings.append_all(quote! { ref #ident, });
+                        stmts.append_all(quote! { { debug.field(#ident); } });
                     }
                     quote! {
-                        #tag ( #(#bindings),* ) => f.debug_tuple(#var_name) #items .finish(),
+                        #tag ( #bindings ) => { #stmts; debug.finish() },
                     }
                 }
                 Fields::Unit => quote! { #tag => f.write_str(#var_name), },
@@ -222,46 +238,52 @@ impl ImplTrait for ImplDebug {
 
     fn struct_items(&self, item: &ItemStruct, args: &ImplArgs) -> Result<(Toks, Toks)> {
         let type_name = item.ident.to_string();
-        let mut inner;
-        match &item.fields {
+        let inner = match &item.fields {
             Fields::Named(fields) => {
-                inner = quote! { f.debug_struct(#type_name) };
+                let mut stmts = quote! { let mut debug = f.debug_struct(#type_name); };
                 let mut no_skips = true;
                 for field in fields.named.iter() {
+                    for attr in &field.attrs {
+                        if attr.path().get_ident().is_some_and(|path| path == "cfg") {
+                            attr.to_tokens(&mut stmts);
+                        }
+                    }
+
                     let ident = field.ident.as_ref().unwrap();
                     if !args.ignore_named(ident) {
                         let name = ident.to_string();
-                        inner.append_all(quote! {
-                            .field(#name, &self.#ident)
-                        });
+                        stmts.append_all(quote! { { debug.field(#name, &self.#ident); } });
                     } else {
                         no_skips = false;
                     }
                 }
                 if no_skips {
-                    inner.append_all(quote! { .finish() });
+                    quote! { #stmts; debug.finish() }
                 } else {
-                    inner.append_all(quote! { .finish_non_exhaustive() });
-                };
+                    quote! { #stmts; debug.finish_non_exhaustive() }
+                }
             }
             Fields::Unnamed(fields) => {
-                inner = quote! { f.debug_tuple(#type_name) };
-                for i in 0..fields.unnamed.len() {
+                let mut stmts = quote! { let mut debug = f.debug_tuple(#type_name); };
+                for (i, field) in fields.unnamed.iter().enumerate() {
+                    for attr in &field.attrs {
+                        if attr.path().get_ident().is_some_and(|path| path == "cfg") {
+                            attr.to_tokens(&mut stmts);
+                        }
+                    }
+
                     let index = Index::from(i);
                     if !args.ignore_unnamed(&index) {
-                        inner.append_all(quote! {
-                            .field(&self.#index)
-                        });
+                        stmts.append_all(quote! { { debug.field(&self.#index); } });
                     } else {
-                        inner.append_all(quote! {
-                            .field(&format_args!("_"))
-                        });
+                        stmts.append_all(quote! { { debug.field(&format_args!("_")); } });
                     }
                 }
-                inner.append_all(quote! { .finish() });
+                quote! { #stmts; debug.finish() }
             }
-            Fields::Unit => inner = quote! { f.write_str(#type_name) },
+            Fields::Unit => quote! { f.write_str(#type_name) },
         };
+
         let method = quote! {
             fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
                 #inner

--- a/tests/for_deref.rs
+++ b/tests/for_deref.rs
@@ -11,6 +11,7 @@ use impl_tools::autoimpl;
 
 #[autoimpl(for<'a, T: trait> &'a mut T, Box<T>)]
 trait Z {
+    #[allow(unused)]
     const A: i32;
 
     fn f(&self);

--- a/tests/test-cfg/Cargo.toml
+++ b/tests/test-cfg/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "test-cfg"
+version = "0.1.0"
+authors.workspace = true
+license.workspace = true
+rust-version.workspace = true
+edition.workspace = true
+publish = false
+
+[features]
+feature1 = []
+
+[dependencies]
+impl-tools = { version = "0.11", path = "../.." }

--- a/tests/test-cfg/tests/autoimpl.rs
+++ b/tests/test-cfg/tests/autoimpl.rs
@@ -4,7 +4,7 @@
 
 use impl_tools::autoimpl;
 
-#[autoimpl(Clone, Debug where T: trait)]
+#[autoimpl(Clone, Debug, Default where T: trait)]
 #[derive(PartialEq, Eq)]
 struct S<T> {
     a: T,
@@ -31,6 +31,7 @@ impl<T> S<T> {
 fn test_clone_S() {
     let a = S::new(());
     assert_eq!(a.clone(), a);
+    assert!(a != S::default());
 }
 
 #[test]

--- a/tests/test-cfg/tests/autoimpl.rs
+++ b/tests/test-cfg/tests/autoimpl.rs
@@ -1,0 +1,67 @@
+//! Test that autoimpl can handle cfg on fields
+
+#![allow(non_snake_case)]
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct S<T> {
+    a: T,
+    #[cfg(unix)]
+    b: String,
+    #[cfg(not(unix))]
+    b: Box<str>,
+    #[cfg(feature = "feature1")]
+    c: Vec<i32>,
+}
+
+impl<T> S<T> {
+    fn new(a: T) -> Self {
+        S {
+            a,
+            b: "hello world".to_string().into(),
+            #[cfg(feature = "feature1")]
+            c: vec![1, 1, 2, 3, 5, 8],
+        }
+    }
+}
+
+#[test]
+fn test_clone_S() {
+    let a = S::new(());
+    assert_eq!(a.clone(), a);
+}
+
+#[test]
+fn test_debug_S() {
+    let s = S::new(42);
+    #[cfg(not(feature = "feature1"))]
+    let expected = "S { a: 42, b: \"hello world\" }";
+    #[cfg(feature = "feature1")]
+    let expected = "S { a: 42, b: \"hello world\", c: [1, 1, 2, 3, 5, 8] }";
+    assert_eq!(format!("{s:?}"), expected);
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum E<T> {
+    A(T),
+    #[cfg(unix)]
+    B(String),
+    #[cfg(not(unix))]
+    B(Box<str>),
+    #[cfg(feature = "feature1")]
+    C(Vec<i32>),
+}
+
+#[test]
+fn test_clone_E() {
+    let a = E::A(2.2);
+    assert_eq!(a.clone(), a);
+
+    let b = E::<()>::B("rain".to_string().into());
+    assert_eq!(b.clone(), b);
+
+    #[cfg(feature = "feature1")]
+    {
+        let c = E::<()>::C(vec![1, 2, 3]);
+        assert_eq!(c.clone(), c);
+    }
+}

--- a/tests/test-cfg/tests/autoimpl.rs
+++ b/tests/test-cfg/tests/autoimpl.rs
@@ -51,8 +51,10 @@ enum E<T> {
     B(String),
     #[cfg(not(unix))]
     B(Box<str>),
-    #[cfg(feature = "feature1")]
-    C(Vec<i32>),
+    C {
+        #[cfg(feature = "feature1")]
+        nums: Vec<i32>,
+    },
 }
 
 #[test]
@@ -63,9 +65,9 @@ fn test_clone_E() {
     let b = E::<()>::B("rain".to_string().into());
     assert_eq!(b.clone(), b);
 
-    #[cfg(feature = "feature1")]
-    {
-        let c = E::<()>::C(vec![1, 2, 3]);
-        assert_eq!(c.clone(), c);
-    }
+    let c = E::<()>::C {
+        #[cfg(feature = "feature1")]
+        nums: vec![1, 2, 3],
+    };
+    assert_eq!(c.clone(), c);
 }

--- a/tests/test-cfg/tests/autoimpl.rs
+++ b/tests/test-cfg/tests/autoimpl.rs
@@ -2,7 +2,10 @@
 
 #![allow(non_snake_case)]
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+use impl_tools::autoimpl;
+
+#[autoimpl(Clone where T: trait)]
+#[derive(Debug, PartialEq, Eq)]
 struct S<T> {
     a: T,
     #[cfg(unix)]
@@ -40,7 +43,8 @@ fn test_debug_S() {
     assert_eq!(format!("{s:?}"), expected);
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[autoimpl(Clone where T: trait)]
+#[derive(Debug, PartialEq, Eq)]
 enum E<T> {
     A(T),
     #[cfg(unix)]

--- a/tests/test-cfg/tests/autoimpl.rs
+++ b/tests/test-cfg/tests/autoimpl.rs
@@ -4,8 +4,8 @@
 
 use impl_tools::autoimpl;
 
-#[autoimpl(Clone where T: trait)]
-#[derive(Debug, PartialEq, Eq)]
+#[autoimpl(Clone, Debug where T: trait)]
+#[derive(PartialEq, Eq)]
 struct S<T> {
     a: T,
     #[cfg(unix)]
@@ -43,8 +43,8 @@ fn test_debug_S() {
     assert_eq!(format!("{s:?}"), expected);
 }
 
-#[autoimpl(Clone where T: trait)]
-#[derive(Debug, PartialEq, Eq)]
+#[autoimpl(Clone, Debug where T: trait)]
+#[derive(PartialEq, Eq)]
 enum E<T> {
     A(T),
     #[cfg(unix)]


### PR DESCRIPTION
This adds additional tests, then implements support for `#[cfg]` attributes on struct fields, enum variants and variant fields for the traits mentioned in the title.

Work is incomplete: other traits do not support `#[cfg]`. `#[derive]` does of course, so motivation here is limited.

Also supports `ignore` for named fields of enum variants in `Clone` and `Debug`.