### PR TITLE
Prepare 0.11.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# [0.12.0] — unreleased
+# [0.11.4] — unreleased
 
 -   Bump MSRV to 1.70 (#59)
+-   Add feature `nightly-diagnostics` (#60)
+-   Warn on usage of `#[autoimpl]` for traits where a method has a `Self: Sized` bound, with opt-out feature `allow-trait-autoimpl-with-sized-fn-bound` (#60)
 -   Let `#[autoimpl(Clone, Debug, Default)]` support `#[cfg]` on struct fields, enum variants and variant fields (#59)
 -   Let `#[autoimpl(Clone, Debug)]` support `ignore` on named enum fields (#59)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 
 [package]
 name = "impl-tools"
-version = "0.11.2"
+version = "0.11.4"
 description = "Helper macros: autoimpl"
 keywords = ["proc-macro", "macro", "derive", "trait", "procedural"]
 categories = ["development-tools::procedural-macro-helpers"]
@@ -39,7 +39,7 @@ default-features = false
 version = "2.0.0"
 
 [dependencies.impl-tools-lib]
-version = "0.11.1"
+version = "0.11.4"
 path = "lib"
 
 [dev-dependencies]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "impl-tools-lib"
-version = "0.11.3"
+version = "0.11.4"
 description = "Helper macros: autoimpl"
 keywords = ["derive", "trait"]
 readme = "README.md"


### PR DESCRIPTION
CHANGELOG:

-   Bump MSRV to 1.70 (#59)
-   Add feature `nightly-diagnostics` (#60)
-   Warn on usage of `#[autoimpl]` for traits where a method has a `Self: Sized` bound, with opt-out feature `allow-trait-autoimpl-with-sized-fn-bound` (#60)
-   Let `#[autoimpl(Clone, Debug, Default)]` support `#[cfg]` on struct fields, enum variants and variant fields (#59)
-   Let `#[autoimpl(Clone, Debug)]` support `ignore` on named enum fields (#59)
