### PR TITLE
Add `#[split_impl]` attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,26 @@ impl_tools::impl_scope! {
 
 Note: `#[impl_default]` is matched within an `impl_scope!` regardless of imports.
 
+
+### Split Impl
+
+Sometimes a trait is used only (or primarily) to provide an interface over a single object. In such cases, writing out the method prototypes twice (in both the trait and its implementation) should be unnecessary.
+
+Example:
+```rust
+#[impl_tools::split_impl(for str)]
+trait Greet {
+    /// Introduce yourself
+    fn greet(&self) {
+        println!("Hello world, I am {self}!");
+    }
+}
+
+fn main() {
+    "Ferris".greet();
+}
+```
+
 ### Impl Self
 
 `#[impl_self]` provides `impl Self` syntax, avoiding the

--- a/lib/src/autoimpl/for_deref.rs
+++ b/lib/src/autoimpl/for_deref.rs
@@ -6,6 +6,7 @@
 //! Implementation of the `#[autoimpl]` attribute
 
 use crate::generics::{GenericParam, Generics, TypeParamBound, WherePredicate};
+use crate::propegate_attr_to_impl;
 use proc_macro2::{Span, TokenStream};
 use proc_macro_error2::{emit_call_site_error, emit_call_site_warning, emit_error};
 use quote::{quote, ToTokens, TokenStreamExt};
@@ -90,13 +91,6 @@ mod parsing {
             })
         }
     }
-}
-
-// HACK: there is no definitive determination of which attributes should be
-// emitted on the generated impl fn items. We use a whitelist.
-fn propegate_attr_to_impl(attr: &syn::Attribute) -> bool {
-    let path = attr.path().to_token_stream().to_string();
-    matches!(path.as_str(), "cfg" | "allow" | "warn" | "deny" | "forbid")
 }
 
 fn has_bound_on_self(gen: &syn::Generics) -> bool {

--- a/lib/src/autoimpl/for_deref.rs
+++ b/lib/src/autoimpl/for_deref.rs
@@ -6,7 +6,7 @@
 //! Implementation of the `#[autoimpl]` attribute
 
 use crate::generics::{GenericParam, Generics, TypeParamBound, WherePredicate};
-use crate::propegate_attr_to_impl;
+use crate::utils::propegate_attr_to_impl;
 use proc_macro2::{Span, TokenStream};
 use proc_macro_error2::{emit_call_site_error, emit_call_site_warning, emit_error};
 use quote::{quote, ToTokens, TokenStreamExt};

--- a/lib/src/autoimpl/for_deref.rs
+++ b/lib/src/autoimpl/for_deref.rs
@@ -214,13 +214,13 @@ impl ForDeref {
                                 // Substitute a fresh ident
                                 let name = format!("arg{i}");
                                 let ident = Ident::new(&name, Span::call_site());
-                                ty.pat = Box::new(Pat::Ident(syn::PatIdent {
+                                *ty.pat = Pat::Ident(syn::PatIdent {
                                     attrs: vec![],
                                     by_ref: None,
                                     mutability: None,
                                     ident,
                                     subpat: None,
-                                }));
+                                });
                             }
                         }
                     }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -21,12 +21,12 @@ pub mod fields;
 pub mod generics;
 pub mod scope;
 mod split_impl;
+mod utils;
 
 pub use default::ImplDefault;
 pub use split_impl::SplitImpl;
 
 use proc_macro2::Span;
-use quote::ToTokens;
 use syn::Ident;
 
 /// Tool to make a formatted [`Ident`](struct@Ident)
@@ -159,13 +159,4 @@ impl SimplePath {
             self.matches(path)
         }
     }
-}
-
-/// Determine whether to copy an attribute from a declaration to an implementation.
-///
-/// This is a HACK: there is no definitive determination of which attributes
-/// should be emitted on the generated impl fn items. We use a whitelist.
-fn propegate_attr_to_impl(attr: &syn::Attribute) -> bool {
-    let path = attr.path().to_token_stream().to_string();
-    matches!(path.as_str(), "cfg" | "allow" | "warn" | "deny" | "forbid")
 }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -22,7 +22,9 @@ pub mod generics;
 pub mod scope;
 
 pub use default::ImplDefault;
+
 use proc_macro2::Span;
+use quote::ToTokens;
 use syn::Ident;
 
 /// Tool to make a formatted [`Ident`](struct@Ident)
@@ -155,4 +157,13 @@ impl SimplePath {
             self.matches(path)
         }
     }
+}
+
+/// Determine whether to copy an attribute from a declaration to an implementation.
+///
+/// This is a HACK: there is no definitive determination of which attributes
+/// should be emitted on the generated impl fn items. We use a whitelist.
+fn propegate_attr_to_impl(attr: &syn::Attribute) -> bool {
+    let path = attr.path().to_token_stream().to_string();
+    matches!(path.as_str(), "cfg" | "allow" | "warn" | "deny" | "forbid")
 }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -20,8 +20,10 @@ mod default;
 pub mod fields;
 pub mod generics;
 pub mod scope;
+mod split_impl;
 
 pub use default::ImplDefault;
+pub use split_impl::SplitImpl;
 
 use proc_macro2::Span;
 use quote::ToTokens;

--- a/lib/src/scope.rs
+++ b/lib/src/scope.rs
@@ -5,7 +5,7 @@
 
 //! The `impl_scope!` macro
 
-use crate::{fields::Fields, SimplePath};
+use crate::{fields::Fields, utils::extend_generics, SimplePath};
 use proc_macro2::{Span, TokenStream};
 use proc_macro_error2::emit_error;
 use quote::{ToTokens, TokenStreamExt};
@@ -13,8 +13,8 @@ use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
 use syn::token::{Brace, Comma, Semi};
 use syn::{
-    parse_quote, Attribute, FieldsNamed, GenericParam, Generics, Ident, ItemImpl, Path, Result,
-    Token, Type, Variant, Visibility,
+    parse_quote, Attribute, FieldsNamed, Generics, Ident, ItemImpl, Path, Result, Token, Type,
+    Variant, Visibility,
 };
 
 pub use super::default::{find_impl_default, AttrImplDefault};
@@ -524,54 +524,5 @@ mod printing {
             tokens.append_all(self.impls.iter());
             tokens.append_all(self.generated.iter());
         }
-    }
-}
-
-// Support impls on Self by replacing name and summing generics
-fn extend_generics(generics: &mut Generics, in_generics: &Generics) {
-    if generics.lt_token.is_none() {
-        debug_assert!(generics.params.is_empty());
-        debug_assert!(generics.gt_token.is_none());
-        generics.lt_token = in_generics.lt_token;
-        generics.params = in_generics.params.clone();
-        generics.gt_token = in_generics.gt_token;
-    } else if in_generics.lt_token.is_none() {
-        debug_assert!(in_generics.params.is_empty());
-        debug_assert!(in_generics.gt_token.is_none());
-    } else {
-        if !generics.params.empty_or_trailing() {
-            generics.params.push_punct(Default::default());
-        }
-        generics
-            .params
-            .extend(in_generics.params.clone().into_pairs());
-    }
-
-    // Strip defaults which are legal on the struct but not on impls
-    for param in &mut generics.params {
-        match param {
-            GenericParam::Type(p) => {
-                p.eq_token = None;
-                p.default = None;
-            }
-            GenericParam::Lifetime(_) => (),
-            GenericParam::Const(p) => {
-                p.eq_token = None;
-                p.default = None;
-            }
-        }
-    }
-
-    if let Some(ref mut clause1) = generics.where_clause {
-        if let Some(ref clause2) = in_generics.where_clause {
-            if !clause1.predicates.empty_or_trailing() {
-                clause1.predicates.push_punct(Default::default());
-            }
-            clause1
-                .predicates
-                .extend(clause2.predicates.clone().into_pairs());
-        }
-    } else {
-        generics.where_clause = in_generics.where_clause.clone();
     }
 }

--- a/lib/src/split_impl.rs
+++ b/lib/src/split_impl.rs
@@ -64,14 +64,14 @@ impl SplitImpl {
                         attrs: copy_non_doc_attrs(&item.attrs),
                         vis: syn::Visibility::Inherited,
                         defaultness: None,
-                        const_token: item.const_token.clone(),
+                        const_token: item.const_token,
                         ident: item.ident.clone(),
                         generics: item.generics.clone(),
-                        colon_token: item.colon_token.clone(),
+                        colon_token: item.colon_token,
                         ty: item.ty.clone(),
                         eq_token,
                         expr,
-                        semi_token: item.semi_token.clone(),
+                        semi_token: item.semi_token,
                     }));
                 }
                 TraitItem::Fn(item) => {
@@ -100,12 +100,12 @@ impl SplitImpl {
                         attrs: copy_non_doc_attrs(&item.attrs),
                         vis: syn::Visibility::Inherited,
                         defaultness: None,
-                        type_token: item.type_token.clone(),
+                        type_token: item.type_token,
                         ident: item.ident.clone(),
                         generics: item.generics.clone(),
                         eq_token,
                         ty,
-                        semi_token: item.semi_token.clone(),
+                        semi_token: item.semi_token,
                     }));
                 }
                 other => emit_error!(other, "unsupported trait item"),

--- a/lib/src/split_impl.rs
+++ b/lib/src/split_impl.rs
@@ -5,6 +5,7 @@
 
 //! `#[split_impl]`
 
+use crate::utils::{self, copy_non_doc_attrs, PathAsStr};
 use proc_macro2::TokenStream;
 use proc_macro_error2::emit_error;
 use quote::quote;
@@ -45,7 +46,7 @@ impl SplitImpl {
     pub fn process(self, mut trait_: ItemTrait) -> TokenStream {
         let mut attrs = Vec::with_capacity(trait_.attrs.len());
         for attr in &trait_.attrs {
-            if crate::propegate_attr_to_impl(attr) {
+            if utils::propegate_attr_to_impl(attr) {
                 attrs.push(attr.clone());
             }
         }
@@ -60,7 +61,7 @@ impl SplitImpl {
                     };
 
                     items.push(ImplItem::Const(syn::ImplItemConst {
-                        attrs: item.attrs.clone(),
+                        attrs: copy_non_doc_attrs(&item.attrs),
                         vis: syn::Visibility::Inherited,
                         defaultness: None,
                         const_token: item.const_token.clone(),
@@ -80,12 +81,14 @@ impl SplitImpl {
                     };
 
                     items.push(ImplItem::Fn(syn::ImplItemFn {
-                        attrs: item.attrs.clone(),
+                        attrs: copy_non_doc_attrs(&item.attrs),
                         vis: syn::Visibility::Inherited,
                         defaultness: None,
                         sig: item.sig.clone(),
                         block,
                     }));
+
+                    item.attrs.retain(|attr| attr.path_as_string() != "inline");
                 }
                 TraitItem::Type(item) => {
                     let Some((eq_token, ty)) = item.default.take() else {
@@ -94,7 +97,7 @@ impl SplitImpl {
                     };
 
                     items.push(ImplItem::Type(syn::ImplItemType {
-                        attrs: item.attrs.clone(),
+                        attrs: copy_non_doc_attrs(&item.attrs),
                         vis: syn::Visibility::Inherited,
                         defaultness: None,
                         type_token: item.type_token.clone(),

--- a/lib/src/split_impl.rs
+++ b/lib/src/split_impl.rs
@@ -1,0 +1,126 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! `#[split_impl]`
+
+use proc_macro2::TokenStream;
+use proc_macro_error2::emit_error;
+use quote::quote;
+use syn::{Generics, ImplItem, ItemTrait, Token, TraitItem, Type};
+
+/// `#[split_impl]` attribute
+pub struct SplitImpl {
+    for_: Token![for],
+    generics: Generics,
+    target: Box<Type>,
+}
+
+mod parsing {
+    use super::*;
+    use syn::parse::{Parse, ParseStream, Result};
+
+    impl Parse for SplitImpl {
+        fn parse(input: ParseStream) -> Result<Self> {
+            let for_ = input.parse::<Token![for]>()?;
+            let generics = if input.peek(Token![<]) {
+                input.parse()?
+            } else {
+                Generics::default()
+            };
+            let target = input.parse()?;
+
+            Ok(SplitImpl {
+                for_,
+                generics,
+                target,
+            })
+        }
+    }
+}
+
+impl SplitImpl {
+    /// Process input
+    pub fn process(self, mut trait_: ItemTrait) -> TokenStream {
+        let mut attrs = Vec::with_capacity(trait_.attrs.len());
+        for attr in &trait_.attrs {
+            if crate::propegate_attr_to_impl(attr) {
+                attrs.push(attr.clone());
+            }
+        }
+
+        let mut items = Vec::with_capacity(trait_.items.len());
+        for item in trait_.items.iter_mut() {
+            match item {
+                TraitItem::Const(item) => {
+                    let Some((eq_token, expr)) = item.default.take() else {
+                        emit_error!(item, "definition not found");
+                        continue;
+                    };
+
+                    items.push(ImplItem::Const(syn::ImplItemConst {
+                        attrs: item.attrs.clone(),
+                        vis: syn::Visibility::Inherited,
+                        defaultness: None,
+                        const_token: item.const_token.clone(),
+                        ident: item.ident.clone(),
+                        generics: item.generics.clone(),
+                        colon_token: item.colon_token.clone(),
+                        ty: item.ty.clone(),
+                        eq_token,
+                        expr,
+                        semi_token: item.semi_token.clone(),
+                    }));
+                }
+                TraitItem::Fn(item) => {
+                    let Some(block) = item.default.take() else {
+                        emit_error!(item, "definition not found");
+                        continue;
+                    };
+
+                    items.push(ImplItem::Fn(syn::ImplItemFn {
+                        attrs: item.attrs.clone(),
+                        vis: syn::Visibility::Inherited,
+                        defaultness: None,
+                        sig: item.sig.clone(),
+                        block,
+                    }));
+                }
+                TraitItem::Type(item) => {
+                    let Some((eq_token, ty)) = item.default.take() else {
+                        emit_error!(item, "definition not found");
+                        continue;
+                    };
+
+                    items.push(ImplItem::Type(syn::ImplItemType {
+                        attrs: item.attrs.clone(),
+                        vis: syn::Visibility::Inherited,
+                        defaultness: None,
+                        type_token: item.type_token.clone(),
+                        ident: item.ident.clone(),
+                        generics: item.generics.clone(),
+                        eq_token,
+                        ty,
+                        semi_token: item.semi_token.clone(),
+                    }));
+                }
+                other => emit_error!(other, "unsupported trait item"),
+            }
+        }
+
+        let impl_ = syn::ItemImpl {
+            attrs,
+            defaultness: None,
+            unsafety: None,
+            impl_token: Default::default(),
+            generics: self.generics,
+            trait_: Some((None, trait_.ident.clone().into(), self.for_)),
+            self_ty: self.target,
+            brace_token: Default::default(),
+            items,
+        };
+
+        quote! { #trait_ #impl_ }
+    }
+}

--- a/lib/src/split_impl.rs
+++ b/lib/src/split_impl.rs
@@ -112,12 +112,15 @@ impl SplitImpl {
             }
         }
 
+        let mut generics = self.generics;
+        utils::extend_generics(&mut generics, &trait_.generics);
+
         let impl_ = syn::ItemImpl {
             attrs,
             defaultness: None,
             unsafety: None,
             impl_token: Default::default(),
-            generics: self.generics,
+            generics,
             trait_: Some((None, trait_.ident.clone().into(), self.for_)),
             self_ty: self.target,
             brace_token: Default::default(),

--- a/lib/src/utils.rs
+++ b/lib/src/utils.rs
@@ -6,7 +6,7 @@
 //! Utilities
 
 use quote::ToTokens;
-use syn::Attribute;
+use syn::{Attribute, GenericParam, Generics};
 
 pub trait PathAsStr {
     fn path_as_string(&self) -> String;
@@ -38,4 +38,53 @@ pub fn copy_non_doc_attrs(attrs: &[Attribute]) -> Vec<Attribute> {
         }
     }
     dest
+}
+
+/// Copy all generics from `gen2` into `generics`
+///
+/// Also removes default values for generics.
+pub fn extend_generics(generics: &mut Generics, gen2: &Generics) {
+    if generics.lt_token.is_none() {
+        debug_assert!(generics.params.is_empty());
+        debug_assert!(generics.gt_token.is_none());
+        generics.lt_token = gen2.lt_token;
+        generics.params = gen2.params.clone();
+        generics.gt_token = gen2.gt_token;
+    } else if gen2.lt_token.is_none() {
+        debug_assert!(gen2.params.is_empty());
+        debug_assert!(gen2.gt_token.is_none());
+    } else {
+        if !generics.params.empty_or_trailing() {
+            generics.params.push_punct(Default::default());
+        }
+        generics.params.extend(gen2.params.clone().into_pairs());
+    }
+
+    // Strip defaults which are legal on the struct but not on impls
+    for param in &mut generics.params {
+        match param {
+            GenericParam::Type(p) => {
+                p.eq_token = None;
+                p.default = None;
+            }
+            GenericParam::Lifetime(_) => (),
+            GenericParam::Const(p) => {
+                p.eq_token = None;
+                p.default = None;
+            }
+        }
+    }
+
+    if let Some(ref mut clause1) = generics.where_clause {
+        if let Some(ref clause2) = gen2.where_clause {
+            if !clause1.predicates.empty_or_trailing() {
+                clause1.predicates.push_punct(Default::default());
+            }
+            clause1
+                .predicates
+                .extend(clause2.predicates.clone().into_pairs());
+        }
+    } else {
+        generics.where_clause = gen2.where_clause.clone();
+    }
 }

--- a/lib/src/utils.rs
+++ b/lib/src/utils.rs
@@ -1,0 +1,41 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Utilities
+
+use quote::ToTokens;
+use syn::Attribute;
+
+pub trait PathAsStr {
+    fn path_as_string(&self) -> String;
+}
+
+impl PathAsStr for Attribute {
+    fn path_as_string(&self) -> String {
+        self.path().to_token_stream().to_string()
+    }
+}
+
+/// Determine whether to copy an attribute from a declaration to an implementation.
+///
+/// This is a HACK: there is no definitive determination of which attributes
+/// should be emitted on the generated impl fn items. We use a whitelist.
+pub fn propegate_attr_to_impl(attr: &Attribute) -> bool {
+    matches!(
+        attr.path_as_string().as_str(),
+        "cfg" | "allow" | "warn" | "deny" | "forbid"
+    )
+}
+
+/// Copy all attrs except `#[doc]`
+pub fn copy_non_doc_attrs(attrs: &[Attribute]) -> Vec<Attribute> {
+    let mut dest = Vec::with_capacity(attrs.len());
+    for attr in attrs {
+        if attr.path_as_string() != "doc" {
+            dest.push(attr.clone());
+        }
+    }
+    dest
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -302,6 +302,48 @@ pub fn autoimpl(attr: TokenStream, item: TokenStream) -> TokenStream {
 }
 
 /// Support simultaneous definition of a trait and its implementation
+///
+/// Sometimes a trait is used only (or primarily) to provide an interface over a
+/// single object. In such cases, writing out the method prototypes twice (in
+/// both the trait and its implementation) should be unnecessary.
+///
+/// This attribute splits an implementation for a specified target off from a
+/// trait definition.
+///
+/// # Details
+///
+/// This attribute must be applied to a trait definition. This trait definition
+/// is retained with only modifications being that method *implementations* and
+/// `#[inline]` attributes are removed. An implied limitation of this attribute
+/// is that methods of the trait cannot have default implementations.
+///
+/// Meanwhile, an implementation of the trait is generated for the given target.
+/// This implementation uses all method implementations from the trait.
+///
+/// Generics may be introduced for the implementation only using syntax like
+/// `#[split_impl(for<'a, T> Target<'a, T>)]`. Implementation generics are
+/// combined with trait generics.
+///
+/// Specific attributes of the trait are copied to the implementation: `cfg`,
+/// `allow`, `warn`, `deny`, `forbid`. All trait method attributes except `doc`
+/// are copied to the implementation.
+///
+/// # Example
+///
+/// ```
+/// # use impl_tools::split_impl;
+/// #[split_impl(for str)]
+/// trait Greet {
+///     /// Introduce yourself
+///     fn greet(&self) {
+///         println!("Hello world, I am {self}!");
+///     }
+/// }
+///
+/// fn main() {
+///     "Ferris".greet();
+/// }
+/// ```
 #[proc_macro_attribute]
 #[proc_macro_error]
 pub fn split_impl(attr: TokenStream, item: TokenStream) -> TokenStream {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -301,6 +301,22 @@ pub fn autoimpl(attr: TokenStream, item: TokenStream) -> TokenStream {
     toks
 }
 
+/// Support simultaneous definition of a trait and its implementation
+#[proc_macro_attribute]
+#[proc_macro_error]
+pub fn split_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
+    match syn::parse::<lib::SplitImpl>(attr) {
+        Ok(attr) => match syn::parse::<syn::ItemTrait>(item) {
+            Ok(trait_) => attr.process(trait_).into(),
+            Err(err) => err.to_compile_error().into(),
+        },
+        Err(err) => {
+            emit_call_site_error!(err);
+            item
+        }
+    }
+}
+
 /// Implement a type with `impl Self` syntax
 ///
 /// This macro facilitates definition of a type (struct, enum or union) plus

--- a/tests/split_impl.rs
+++ b/tests/split_impl.rs
@@ -1,0 +1,54 @@
+//! Test impl_for attribute
+use impl_tools::split_impl;
+
+struct Object<T> {
+    name: String,
+    mass: T,
+}
+
+#[split_impl(for<T: Copy + Into<f64>> Object<T>)]
+trait Interface {
+    /// Get the name
+    #[inline]
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Get the weight (Lb)
+    fn weight(&self) -> f64 {
+        let m: f64 = self.mass.into();
+        m * 2.2046244201837775
+    }
+}
+
+#[test]
+fn test_stone() {
+    let obj = Object {
+        name: "stone".to_string(),
+        mass: 6.350288,
+    };
+
+    let iface: &dyn Interface = &obj;
+    assert_eq!(iface.name(), "stone");
+    assert_eq!(iface.weight(), 14.0);
+}
+
+struct Brick;
+impl Interface for Brick {
+    #[inline]
+    fn name(&self) -> &str {
+        "brick"
+    }
+
+    #[inline]
+    fn weight(&self) -> f64 {
+        5.0
+    }
+}
+
+#[test]
+fn test_brick() {
+    let iface: &dyn Interface = &Brick;
+    assert_eq!(iface.name(), "brick");
+    assert_eq!(iface.weight(), 5.0);
+}


### PR DESCRIPTION
Sometimes a trait is used only (or primarily) to provide an interface over a single object. In such cases, writing out the method prototypes twice (in both the trait and its implementation) should be unnecessary.

Example:
```rust
#[impl_tools::split_impl(for str)]
trait Greet {
    /// Introduce yourself
    fn greet(&self) {
        println!("Hello world, I am {self}!");
    }
}

fn main() {
    "Ferris".greet();
}
```