### PR TITLE
Fixes for `#[split_impl]`

### DIFF
--- a/lib/src/split_impl.rs
+++ b/lib/src/split_impl.rs
@@ -25,12 +25,15 @@ mod parsing {
     impl Parse for SplitImpl {
         fn parse(input: ParseStream) -> Result<Self> {
             let for_ = input.parse::<Token![for]>()?;
-            let generics = if input.peek(Token![<]) {
+            let mut generics = if input.peek(Token![<]) {
                 input.parse()?
             } else {
                 Generics::default()
             };
             let target = input.parse()?;
+            if input.peek(Token![where]) {
+                generics.where_clause = Some(input.parse()?);
+            }
 
             Ok(SplitImpl {
                 for_,

--- a/lib/src/split_impl.rs
+++ b/lib/src/split_impl.rs
@@ -9,7 +9,7 @@ use crate::utils::{self, copy_non_doc_attrs, PathAsStr};
 use proc_macro2::TokenStream;
 use proc_macro_error2::emit_error;
 use quote::quote;
-use syn::{Generics, ImplItem, ItemTrait, Token, TraitItem, Type};
+use syn::{parse_quote, Generics, ImplItem, ItemTrait, Token, TraitItem, Type};
 
 /// `#[split_impl]` attribute
 pub struct SplitImpl {
@@ -118,13 +118,17 @@ impl SplitImpl {
         let mut generics = self.generics;
         utils::extend_generics(&mut generics, &trait_.generics);
 
+        let ident = &trait_.ident;
+        let (_, ty_generics, _) = trait_.generics.split_for_impl();
+        let path = parse_quote! { #ident #ty_generics };
+
         let impl_ = syn::ItemImpl {
             attrs,
             defaultness: None,
             unsafety: None,
             impl_token: Default::default(),
             generics,
-            trait_: Some((None, trait_.ident.clone().into(), self.for_)),
+            trait_: Some((None, path, self.for_)),
             self_ty: self.target,
             brace_token: Default::default(),
             items,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -321,8 +321,8 @@ pub fn autoimpl(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// This implementation uses all method implementations from the trait.
 ///
 /// Generics may be introduced for the implementation only using syntax like
-/// `#[split_impl(for<'a, T> Target<'a, T>)]`. Implementation generics are
-/// combined with trait generics.
+/// `#[split_impl(for<'a, T> Target<'a, T> where T: Trait)]`.
+/// Implementation generics are combined with trait generics.
 ///
 /// Specific attributes of the trait are copied to the implementation: `cfg`,
 /// `allow`, `warn`, `deny`, `forbid`. All trait method attributes except `doc`


### PR DESCRIPTION
A couple of fixes to #63 (discovered while applying to Kas):

- Support a `where` clause in generics applied to the impl. A shame the result is so ugly for long lines.
- Copy generics on the trait to the impl.