### PR TITLE
Support `#[autoimpl]` for traits with non-generic targets

### DIFF
--- a/lib/src/autoimpl/for_deref.rs
+++ b/lib/src/autoimpl/for_deref.rs
@@ -33,14 +33,8 @@ mod parsing {
 
             let targets = Punctuated::parse_separated_nonempty(input)?;
 
-            let mut lookahead = input.lookahead1();
-            if lookahead.peek(Token![where]) {
+            if input.peek(Token![where]) {
                 generics.where_clause = Some(input.parse()?);
-                lookahead = input.lookahead1();
-            }
-
-            if !input.is_empty() {
-                return Err(lookahead.error());
             }
 
             let mut definitive: Option<Ident> = None;

--- a/lib/src/autoimpl/for_deref.rs
+++ b/lib/src/autoimpl/for_deref.rs
@@ -13,13 +13,19 @@ use quote::{quote, ToTokens, TokenStreamExt};
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
 use syn::token::{Comma, Eq, PathSep};
-use syn::{parse_quote, FnArg, Ident, Item, Pat, Token, TraitItem, Type, TypePath};
+use syn::{parse_quote, FnArg, Ident, Item, Member, Pat, Token, TraitItem, Type, TypePath};
+
+mod kw {
+    syn::custom_keyword!(using);
+}
 
 /// Autoimpl for types supporting `Deref`
+#[derive(Debug)]
 pub struct ForDeref {
     generics: Generics,
     definitive: Option<Ident>,
     targets: Punctuated<Type, Comma>,
+    using: Option<Member>,
 }
 
 mod parsing {
@@ -32,6 +38,14 @@ mod parsing {
             let mut generics: Generics = input.parse()?;
 
             let targets = Punctuated::parse_separated_nonempty(input)?;
+
+            let mut using = None;
+            if input.peek(kw::using) {
+                let _: kw::using = input.parse()?;
+                let _: Token![self] = input.parse()?;
+                let _: Token![.] = input.parse()?;
+                using = Some(input.parse()?);
+            }
 
             if input.peek(Token![where]) {
                 generics.where_clause = Some(input.parse()?);
@@ -73,6 +87,7 @@ mod parsing {
                 generics,
                 definitive,
                 targets,
+                using,
             })
         }
     }
@@ -221,26 +236,28 @@ impl ForDeref {
                     }
                     item.sig.to_tokens(tokens);
 
-                    bound = bound.max(match item.sig.inputs.first() {
-                        Some(FnArg::Receiver(rec)) => {
-                            if rec.reference.is_some() {
-                                Bound::Deref(rec.mutability.is_some())
-                            } else {
-                                emit_call_site_error!(
-                                    "cannot autoimpl trait with Deref";
-                                    note = rec.span() => "deref cannot yield `self` by value";
-                                );
-                                Bound::ErrorEmitted
+                    if self.using.is_none() {
+                        bound = bound.max(match item.sig.inputs.first() {
+                            Some(FnArg::Receiver(rec)) => {
+                                if rec.reference.is_some() {
+                                    Bound::Deref(rec.mutability.is_some())
+                                } else {
+                                    emit_call_site_error!(
+                                        "cannot autoimpl trait with Deref";
+                                        note = rec.span() => "deref cannot yield `self` by value";
+                                    );
+                                    Bound::ErrorEmitted
+                                }
                             }
-                        }
-                        Some(FnArg::Typed(ref pat)) => match &*pat.ty {
-                            Type::Reference(rf) if rf.elem == parse_quote! { Self } => {
-                                Bound::Deref(rf.mutability.is_some())
-                            }
+                            Some(FnArg::Typed(ref pat)) => match &*pat.ty {
+                                Type::Reference(rf) if rf.elem == parse_quote! { Self } => {
+                                    Bound::Deref(rf.mutability.is_some())
+                                }
+                                _ => Bound::None,
+                            },
                             _ => Bound::None,
-                        },
-                        _ => Bound::None,
-                    });
+                        });
+                    }
 
                     let ident = &item.sig.ident;
                     let params = item.sig.inputs.iter().map(|arg| {
@@ -252,7 +269,18 @@ impl ForDeref {
                                         attr.to_tokens(&mut toks);
                                     }
                                 }
-                                arg.self_token.to_tokens(&mut toks);
+                                if let Some(member) = self.using.as_ref() {
+                                    if let Some((r, _)) = arg.reference {
+                                        r.to_tokens(&mut toks);
+                                    }
+                                    if let Some(m) = arg.mutability {
+                                        m.to_tokens(&mut toks);
+                                    }
+                                    let self_ = &arg.self_token;
+                                    toks.append_all(quote! { #self_ . #member });
+                                } else {
+                                    arg.self_token.to_tokens(&mut toks);
+                                }
                             }
                             FnArg::Typed(arg) => {
                                 for attr in &arg.attrs {

--- a/lib/src/autoimpl/for_deref.rs
+++ b/lib/src/autoimpl/for_deref.rs
@@ -18,13 +18,13 @@ use syn::{parse_quote, FnArg, Ident, Item, Pat, Token, TraitItem, Type, TypePath
 /// Autoimpl for types supporting `Deref`
 pub struct ForDeref {
     generics: Generics,
-    definitive: Ident,
+    definitive: Option<Ident>,
     targets: Punctuated<Type, Comma>,
 }
 
 mod parsing {
     use super::*;
-    use syn::parse::{Error, Parse, ParseStream, Result};
+    use syn::parse::{Parse, ParseStream, Result};
 
     impl Parse for ForDeref {
         fn parse(input: ParseStream) -> Result<Self> {
@@ -68,15 +68,6 @@ mod parsing {
                     }
                 }
             }
-            let definitive = match definitive {
-                Some(def) => def,
-                None => {
-                    return Err(Error::new(
-                        Span::call_site(),
-                        "no definitive type parameter: require a parameter bound like `T: trait``",
-                    ));
-                }
-            };
 
             Ok(ForDeref {
                 generics,
@@ -142,8 +133,13 @@ impl ForDeref {
         let (impl_generics, where_clause) =
             self.generics.impl_generics(&trait_def.generics, &trait_ty);
 
-        let definitive_ty = self.definitive;
-        let definitive = quote! { < #definitive_ty as #trait_ty > };
+        let opt_definitive = self
+            .definitive
+            .as_ref()
+            .map(|ty| quote! { < #ty as #trait_ty > });
+        let fn_definitive = opt_definitive
+            .clone()
+            .unwrap_or_else(|| quote! { #trait_ty });
 
         // Tokenize, like ToTokens impls for syn::TraitItem*, but for definition
         let mut impl_items = TokenStream::new();
@@ -151,6 +147,11 @@ impl ForDeref {
         for item in trait_def.items.into_iter() {
             match item {
                 TraitItem::Const(item) => {
+                    let Some(definitive) = opt_definitive.as_ref() else {
+                        emit_error!(item, "cannot autoimpl an associated constant without a definitive type (e.g. `T: trait`)");
+                        continue;
+                    };
+
                     for attr in item.attrs.iter() {
                         if *attr.path() == parse_quote! { cfg } {
                             attr.to_tokens(tokens);
@@ -266,10 +267,15 @@ impl ForDeref {
                         toks
                     });
                     tokens.append_all(quote! { {
-                        #definitive :: #ident ( #(#params),* )
+                        #fn_definitive :: #ident ( #(#params),* )
                     } });
                 }
                 TraitItem::Type(item) => {
+                    let Some(definitive) = opt_definitive.as_ref() else {
+                        emit_error!(item, "cannot autoimpl an associated type without a definitive type (e.g. `T: trait`)");
+                        continue;
+                    };
+
                     for attr in item.attrs.iter() {
                         if *attr.path() == parse_quote! { cfg } {
                             attr.to_tokens(tokens);
@@ -318,6 +324,11 @@ impl ForDeref {
         match bound {
             Bound::None => (),
             Bound::Deref(is_mut) => {
+                let Some(definitive_ty) = self.definitive.as_ref() else {
+                    emit_call_site_error!("require a definitive type (e.g. `T: trait`)");
+                    return toks;
+                };
+
                 // Emit a bound to improve error messages (see issue 27)
                 let bound = match is_mut {
                     false => quote! { ::core::ops::Deref },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,14 +204,35 @@ pub fn impl_default(args: TokenStream, item: TokenStream) -> TokenStream {
 /// # On trait definitions
 ///
 /// `#[autoimpl]` on trait definitions generates an implementation of that trait
-/// for the given targets. This functions using an implementation of [`Deref`]
-/// (and, where required, [`DerefMut`]) to lower the target type to some other
-/// type supporting the trait. We call this latter type the **definitive type**.
+/// for the given targets over that targets' own implementations of the trait.
+/// Targets may or may not be generic.
 ///
-/// It is required that the target type(s) implemented are generic over some
-/// type parameter(s). These generic parameters are introduced using `for<..>`.
-/// It is further required that at least one generic parameter has a bound on
-/// `trait`; the first such parameter is inferred to be the *definitive type*.
+/// Method implementations either defer to a field (if `using self._Member_` is
+/// specified; e.g. `using self.0` or `using self.inner`) or use [`Deref`] (and,
+/// where required, [`DerefMut`]).
+///
+/// For example,
+/// ```
+/// # use impl_tools::autoimpl;
+/// struct MyVec {
+///     vec: Vec<()>,
+/// }
+///
+/// #[autoimpl(for MyVec using self.vec)]
+/// trait IsEmpty {
+///     fn is_empty(&self) -> bool;
+/// }
+///
+/// impl<T> IsEmpty for Vec<T> {
+///     fn is_empty(&self) -> bool {
+///         Vec::is_empty(self)
+///     }
+/// }
+/// ```
+///
+/// Associated `const` and `type` items are only supported where the targets are
+/// generic over some parameter with a bound like `T: trait`. We call this the
+/// **definitive type**.
 ///
 /// For example, the following usage implements `MyTrait` for targets `&T`,
 /// `&mut T` and `Box<dyn MyTrait>` using definitive type `T`:
@@ -219,17 +240,22 @@ pub fn impl_default(args: TokenStream, item: TokenStream) -> TokenStream {
 /// # use impl_tools::autoimpl;
 /// #[autoimpl(for<T: trait + ?Sized> &T, &mut T, Box<T>)]
 /// trait MyTrait {
-///     fn f(&self) -> String;
+///     type X;
+///
+///     fn f(&self) -> Self::X;
 /// }
 /// ```
 /// The expansion for target `Box<T>` looks like:
 /// ```
 /// # trait MyTrait {
-/// #     fn f(&self) -> String;
+/// #     type X;
+/// #     fn f(&self) -> Self::X;
 /// # }
 /// #[automatically_derived]
 /// impl<T: MyTrait + ?Sized> MyTrait for Box<T> {
-///     fn f(&self) -> String {
+///     type X = <T as MyTrait>::X;
+///
+///     fn f(&self) -> Self::X {
 ///         <T as MyTrait>::f(self)
 ///     }
 /// }


### PR DESCRIPTION
This allows some (possibly rather useless) impls like this:
```rust
struct MyVec {
    vec: Vec<()>,
}

#[autoimpl(for MyVec using self.vec)]
trait IsEmpty {
    fn is_empty(&self) -> bool;
}

impl<T> IsEmpty for Vec<T> {
    fn is_empty(&self) -> bool {
        Vec::is_empty(self)
    }
}
```

Of course, this *should* be done using `#[autoimpl(IsEmpty using self.vec)]` on `struct MyVec`, but without writing a custom extension to `impl-tools-lib` specifically for the `IsEmpty` trait that isn't possible.